### PR TITLE
Fix redirections : links with '.html' extensions were not redirected

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -83,10 +83,10 @@ module.exports = function (eleventyConfig) {
 
     // We remove the extension to prevent 11ty from throwing errors as it tries to write, for example : `/en/all.html/index.html`
     if (path.includes('index.html')) {
-      return path.replace('index.html', '')
+      return `/${path.replace('index.html', '')}/`
     }
 
-    return path.replace('.html', '')
+    return `/${path}/`
   })
 
   eleventyConfig.addNunjucksFilter('getDefaultLocale', function (locales, outputKey = null) {

--- a/src/redirections.njk
+++ b/src/redirections.njk
@@ -3,7 +3,7 @@ pagination:
   data: redirections
   size: 1
   alias: redirection
-permalink: "/{{ redirection.old | redirectionPermalink }}/"
+permalink: "{{ redirection.old | redirectionPermalink }}"
 ---
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Links pointing directly to an 'index.html' URL still won't work. We
cannot output two redirection files for one input URL