### PR TITLE
refactor(translation): use a filter instead of a shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -41,25 +41,6 @@ module.exports = function (eleventyConfig) {
       .use(config.eleventy.markdownItCustomParser)
   )
 
-  /**
-   * @see https://stackoverflow.com/questions/6393943/convert-javascript-string-in-dot-notation-into-an-object-reference#answer-6394168
-   */
-  eleventyConfig.addShortcode('translate', function (key, locale) {
-    if (!locales.hasOwnProperty(locale)) {
-      throw new Error(`[translate]: Translation's locale \`${locale}\` does not exist`)
-    }
-
-    key = `${locale}.${key}`
-
-    const translation = key.split('.').reduce((acc, i) => acc[i], locales)
-
-    if (typeof translation === 'undefined') {
-      throw new Error(`[translate]: No translation found for key \`${key}\``)
-    }
-
-    return translation
-  })
-
   eleventyConfig.addShortcode('currentYear', function () {
     return String(new Date().getFullYear())
   })
@@ -80,6 +61,27 @@ module.exports = function (eleventyConfig) {
     }
 
     return new Intl.DateTimeFormat(locale, options).format(date)
+  })
+
+  /**
+   * @see https://stackoverflow.com/questions/6393943/convert-javascript-string-in-dot-notation-into-an-object-reference#answer-6394168
+   */
+  eleventyConfig.addFilter('translate', function (key) {
+    const locale = this.ctx.locale
+
+    if (!locales.hasOwnProperty(locale)) {
+      throw new Error(`[translate]: Translation's locale \`${locale}\` does not exist`)
+    }
+
+    key = `${locale}.${key}`
+
+    const translation = key.split('.').reduce((acc, i) => acc[i], locales)
+
+    if (typeof translation === 'undefined') {
+      throw new Error(`[translate]: No translation found for key \`${key}\``)
+    }
+
+    return translation
   })
 
   eleventyConfig.addFilter('redirectionPermalink', function (path) {

--- a/src/_includes/components/breadcrumbs.njk
+++ b/src/_includes/components/breadcrumbs.njk
@@ -1,7 +1,7 @@
 {% set breadcrumb = navigation.main | getBreadcrumb(locale, page, title) %}
 
 <nav role="navigation" aria-labelledby="breadcrumb-label">
-  <p id="breadcrumb-label" class="sr-only">{% translate 'breadcrumb.label', locale %}</p>
+  <p id="breadcrumb-label" class="sr-only">{{ 'breadcrumb.label' | translate }}</p>
   <ol class="breadcrumb">
     {%- for item in breadcrumb -%}
       {% set beforeLast = loop.index == breadcrumb | length - 1 %}

--- a/src/_includes/components/header/main-navigation.njk
+++ b/src/_includes/components/header/main-navigation.njk
@@ -1,12 +1,12 @@
 {% import "../ui.njk" as ui with context %}
 
 <div class="navbar navbar-dark navbar-expand-md">
-  <nav id="main-menu" class="container-lg justify-content-md-start" role="navigation" aria-label="{% translate "navigation.main.label", locale %}">
-    <a href="/{{ locale }}" class="navbar-brand" title="{% translate 'header.logoAlt', locale %}">
-      <img src="/assets/images/orange-logo.svg" alt="{% translate 'header.logoAlt', locale %}" width="50" height="50">
+  <nav id="main-menu" class="container-lg justify-content-md-start" role="navigation" aria-label="{{ 'navigation.main.label' | translate }}">
+    <a href="/{{ locale }}" class="navbar-brand" title="{{ 'header.logoAlt' | translate }}">
+      <img src="/assets/images/orange-logo.svg" alt="{{ 'header.logoAlt' | translate }}" width="50" height="50">
     </a>
 
-    <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#main-menu-list" aria-controls="main-menu-list" aria-expanded="false" aria-label="{% translate "navigation.main.burgerLabel", locale %}">
+    <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#main-menu-list" aria-controls="main-menu-list" aria-expanded="false" aria-label="{{ 'navigation.main.burgerLabel' | translate }}">
       <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/src/_includes/components/header/secondary-navigation.njk
+++ b/src/_includes/components/header/secondary-navigation.njk
@@ -1,7 +1,7 @@
 {% import "../ui.njk" as ui with context %}
 
 {%- if page | shouldDisplaySecondaryNavigation(locale) -%}
-<nav id="secondary-navigation" class="o-nav-local navbar-light mb-1" role="navigation" aria-label="{% translate "navigation.secondary.label", locale %}">
+<nav id="secondary-navigation" class="o-nav-local navbar-light mb-1" role="navigation" aria-label="{{ 'navigation.secondary.label' | translate }}">
   <div class="container-lg">
     <ul class="nav">
       {%- for category in navigation.main[locale] -%}

--- a/src/_includes/components/header/skip-links.njk
+++ b/src/_includes/components/header/skip-links.njk
@@ -1,4 +1,4 @@
-<nav role="navigation" aria-label="{% translate "skiplinks.label", locale %}">
+<nav role="navigation" aria-label="{{ 'skiplinks.label' | translate }}">
   <ul class="navbar-nav">
     {%- for link in navigation.top[locale] -%}
       <li class="nav-item">

--- a/src/_includes/components/ui.njk
+++ b/src/_includes/components/ui.njk
@@ -74,9 +74,10 @@
       {% if displayTags == true and tags %}
         <ul class="list-inline">
           {%- for tag in tags -%}
+            {%- set tagTranslationKey = 'tags.' + tag -%}
             <li class="list-inline-item">
               <a href="?tag={{ tag }}" class="badge badge-secondary">
-                <span class="sr-only">{% translate "filtersBar.label", locale %}&nbsp;</span>{% translate "tags." + tag, locale %}
+                <span class="sr-only">{{ 'filtersBar.label' | translate }}&nbsp;</span>{{ tagTranslationKey | translate }}
               </a>
             </li>
           {%- endfor -%}
@@ -95,17 +96,18 @@
 {%- macro filtersBar(posts) -%}
 {% set tags = posts | getPostsTags %}
 <nav id="filtersbar" class="hidden-if-no-js o-nav-local navbar-light mb-4 d-flex align-items-center" aria-labelledby="filtersbar_label" role="navigation">
-  <h2 id="filtersbar_label" class="h6 mb-0 pr-3">{% translate "filtersBar.label", locale %} :</h2>
+  <h2 id="filtersbar_label" class="h6 mb-0 pr-3">{{ 'filtersBar.label' | translate }} :</h2>
   <ul class="nav">
     <li class="nav-item">
       <a href="?all" class="nav-link" data-tag="all">
-        <span class="sr-only">{% translate "filtersBar.label", locale %}&nbsp;</span>{% translate "filtersBar.all", locale %}
+        <span class="sr-only">{{ 'filtersBar.label' | translate }}&nbsp;</span>{{ 'filtersBar.all' | translate }}
       </a>
     </li>
     {%- for tag in tags -%}
+      {%- set tagTranslationKey = 'tags.' + tag -%}
       <li class="nav-item">
         <a href="?tag={{ tag }}" class="nav-link" data-tag="{{ tag }}">
-          <span class="sr-only">{% translate "filtersBar.label", locale %}&nbsp;</span>{% translate "tags." + tag, locale %}
+          <span class="sr-only">{{ 'filtersBar.label' | translate }}&nbsp;</span>{{ tagTranslationKey | translate }}
         </a>
       </li>
     {%- endfor -%}
@@ -118,7 +120,7 @@
 {%- if headings | length > 0 -%}
   {%- if mode == "list" -%}
     <nav id="toc" class="bg-200 p-3 d-none d-md-block" role="navigation" aria-labelledby="toc-title">
-      <h2 id="toc-title">{% translate "toc.title", locale %}</h2>
+      <h2 id="toc-title">{{ 'toc.title' | translate }}</h2>
       <ul class="nav flex-column">
         {%- for heading in headings -%}
           <li class="nav-item position-relative">
@@ -130,7 +132,7 @@
   {%- elseif mode == "mobile" -%}
     <nav id="mobile-toc" class="dropdown d-md-none" role="navigation" aria-labelledby="mobile-toc-dropdown-handler">
       <button type="button" class="btn btn-secondary dropdown-toggle" id="mobile-toc-dropdown-handler" data-toggle="dropdown" aria-expanded="false">
-        {% translate "toc.title", locale %}
+        {{ 'toc.title' | translate }}
       </button>
       <div class="dropdown-menu dropdown-menu-right">
         {%- for heading in headings -%}
@@ -146,7 +148,7 @@
 {% if sideNavigationLinks | length > 0 %}
   {%- if mode == "list" -%}
     <nav id="side-navigation" class="d-none d-md-block" role="navigation" aria-labelledby="side-navigation-label">
-      <h2 id="side-navigation-label">{% translate "navigation.side.label", locale %}</h2>
+      <h2 id="side-navigation-label">{{ 'navigation.side.label' | translate }}</h2>
       <ul class="nav flex-column">
         {%- for link in sideNavigationLinks -%}
           <li class="nav-item position-relative">
@@ -158,7 +160,7 @@
   {%- elseif mode == "mobile" -%}
     <nav id="mobile-side-navigation" class="dropdown d-md-none" role="navigation" aria-labelledby="mobile-side-navigation-handler">
       <button type="button" class="btn btn-secondary dropdown-toggle" id="mobile-side-navigation-handler" data-toggle="dropdown" aria-expanded="false">
-        {% translate "navigation.side.label", locale %}
+        {{ 'navigation.side.label' | translate }}
       </button>
       <div class="dropdown-menu dropdown-menu-left">
         {%- for link in sideNavigationLinks -%}
@@ -183,7 +185,7 @@
 
 {%- macro changelang(mode) -%}
 {%- if mode == "supra" -%}
-<nav role="navigation" aria-label="{% translate "changelang.label", locale %}">
+<nav role="navigation" aria-label="{{ 'changelang.label' | translate }}">
   <ul class="navbar-nav">
     {%- for key, lang in site.locales -%}
       {% set active = locale == lang.code %}
@@ -197,7 +199,7 @@
 </nav>
 {%- elseif mode == "mobile" -%}
 <li class="nav-item d-md-none">
-  <span class="sr-only">{% translate "changelang.label", locale %}</span>
+  <span class="sr-only">{{ 'changelang.label' | translate }}</span>
   <ul class="d-flex list-inline">
     {%- for key, lang in site.locales -%}
       {% set active = locale == lang.code %}

--- a/src/_includes/components/wcag-tests-filters.njk
+++ b/src/_includes/components/wcag-tests-filters.njk
@@ -1,9 +1,9 @@
 <aside id="filter">
-  <h2>{% translate "wcagFilters.title", locale %}</h2>
+  <h2>{{ 'wcagFilters.title' | translate }}</h2>
   <div id="feedback"></div>
-  <h3>{% translate "wcagFilters.profiles", locale %}</h3>
+  <h3>{{ 'wcagFilters.profiles' | translate }}</h3>
   <ul id="profils" class="list-unstyled"></ul>
-  <h3>{% translate "wcagFilters.tools", locale %}</h3>
+  <h3>{{ 'wcagFilters.tools' | translate }}</h3>
   <ul id="types" class="list-unstyled"></ul>
   <div id="filter-footer"></div>
 </aside>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -44,8 +44,8 @@
     </div>
     {% block content %}{% endblock %}
     {% include "partials/footer.njk" %}
-    <a href="#" id="back-to-top" class="o-scroll-up static" title="{% translate "backToTop.label", locale %}">
-      <span class="d-none d-sm-inline-block">{% translate "backToTop.label", locale %}</span>
+    <a href="#" id="back-to-top" class="o-scroll-up static" title="{{ 'backToTop.label' | translate }}">
+      <span class="d-none d-sm-inline-block">{{ 'backToTop.label' | translate }}</span>
     </a>
     <script src="/assets/vendors/tarteaucitronjs/tarteaucitron.js"></script>
     {% if jquery == true or boostedJS == true or displayToc == true %}
@@ -87,7 +87,7 @@
         (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager')
       {%- endif -%}
     </script>
-    <div id="a11y_heading_anchor_label" hidden>{% translate "headingsAnchor.label", locale %}</div>
+    <div id="a11y_heading_anchor_label" hidden>{{ 'headingsAnchor.label' | translate }}</div>
     {% include "partials/licence.njk" %}
   </body>
 </html>

--- a/src/_includes/templates/home.njk
+++ b/src/_includes/templates/home.njk
@@ -18,9 +18,9 @@
   <div class="bg-300">
     <section class="container-lg py-4">
       <div class="d-flex">
-        <h2>{% translate 'lastPosts.title', locale %}</h2>
+        <h2>{{ 'lastPosts.title' | translate }}</h2>
         <div class="pl-3">
-          <a href="articles/" class="btn btn-secondary btn-sm">{% translate 'lastPosts.seeAll', locale %}</a>
+          <a href="articles/" class="btn btn-secondary btn-sm">{{ 'lastPosts.seeAll' | translate }}</a>
         </div>
       </div>
       {{ ui.lastPosts(collections["articles_" + locale], site.home.lastPosts.limit) }}


### PR DESCRIPTION
By using a filter instead of a shortcode, we can directly access the
locale variable. Then, there is no more need to add it manually every
time we want to translate something.