### PR TITLE
Fix broken link's URL

### DIFF
--- a/src/fr/web/designer/navigation-clavier.md
+++ b/src/fr/web/designer/navigation-clavier.md
@@ -17,7 +17,7 @@ title: "Navigation au clavier"
 Toutes les fonctionnalités doivent être utilisables à l’aide du clavier uniquement. Le focus doit pouvoir être déplacé sur tous les éléments cliquables (à l’aide de la touche <kbd>Tab</kbd>).  
 Par ailleurs si des fonctionnalités sont spécifiques pour la souris (glisser-déposer, menu apparaissant au clic droit…), faire en sorte que celles-ci soient également disponibles via un autre moyen ailleurs dans l’interface (bouton, icône, menu…). 
 
-Voir [la façon de naviguer au clavier](../../outils/navigation-clavier/) dans un navigateur web.
+Voir [la façon de naviguer au clavier](/fr/web/outils/methodes-et-outils-de-test/navigation-clavier/) dans un navigateur web.
 
 **Exemple&nbsp;:**  
 Dans un webmail, si un clic droit sur le dossier «&nbsp;Corbeille&nbsp;» permet d’accéder à un menu pour vider la corbeille, cette option doit être également disponible via un bouton «&nbsp;Vider la corbeille&nbsp;» ailleurs dans l’interface ou depuis un menu déroulant accessible au clavier.


### PR DESCRIPTION
On the Web -> design page (french version), the "la façon de naviguer au clavier" link was incorrect.

See : https://a11y-guidelines.orange.com/fr/web/designer/navigation-clavier/