### PR TITLE
Mise à jour activation de la navigation clavier avec Safari

### DIFF
--- a/src/fr/web/outils/methodes-et-outils-de-test/navigation-clavier.md
+++ b/src/fr/web/outils/methodes-et-outils-de-test/navigation-clavier.md
@@ -57,5 +57,5 @@ Pour tester si votre service est accessible à l’aide du clavier, vous pouvez 
 
 
 **Remarque&nbsp;: sur Mac la navigation au clavier doit être activée au préalable.**  
-Dans Safari&nbsp;: Edition &gt; Préférences… &gt; Avancées  
-Puis cocher la case *«&nbsp;La touche TAB permet de naviguer parmi les objets des pages web&nbsp;»*.
+Dans Safari &gt; Préférences  
+Cocher la case *«&nbsp;La touche TAB permet de mettre en surbrillance les objets des pages web&nbsp;»*.

--- a/src/fr/web/outils/methodes-et-outils-de-test/navigation-clavier.md
+++ b/src/fr/web/outils/methodes-et-outils-de-test/navigation-clavier.md
@@ -57,5 +57,4 @@ Pour tester si votre service est accessible à l’aide du clavier, vous pouvez 
 
 
 **Remarque&nbsp;: sur Mac la navigation au clavier doit être activée au préalable.**  
-Dans Safari &gt; Préférences &gt; Avancées
-Cocher la case *«&nbsp;La touche TAB permet de mettre en surbrillance les objets des pages web&nbsp;»*.
+Dans Safari &gt; Préférences &gt; Avancées, cocher la case *«&nbsp;La touche TAB permet de mettre en surbrillance les objets des pages web&nbsp;»*.

--- a/src/fr/web/outils/methodes-et-outils-de-test/navigation-clavier.md
+++ b/src/fr/web/outils/methodes-et-outils-de-test/navigation-clavier.md
@@ -57,5 +57,5 @@ Pour tester si votre service est accessible à l’aide du clavier, vous pouvez 
 
 
 **Remarque&nbsp;: sur Mac la navigation au clavier doit être activée au préalable.**  
-Dans Safari &gt; Préférences  
+Dans Safari &gt; Préférences &gt; Avancées
 Cocher la case *«&nbsp;La touche TAB permet de mettre en surbrillance les objets des pages web&nbsp;»*.


### PR DESCRIPTION
Une petite mise à jour du menu qui a changé dans Safari pour activer la navigation au clavier.