### PR TITLE
Add SwiftUI samples

### DIFF
--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -277,6 +277,20 @@ class ChangeTextView: UIViewController {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+struct ChangeTextView: View {
+
+    var body: some View {
+        Text("Some text")
+            .accessibilityLabel(Text("hello"))
+            .accessibilityHint(Text("This is an added comment."))
+            .accessibilityValue(Text("45 per cent"))
+
+        // You can use also raw strings instead of Text views
+    }
+}
+</code></pre>
+
 </div>
 
 </div>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -575,6 +575,7 @@ UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
 </code></pre>
 
 <pre><code class="swift">
+//This API can be used both in UIKit and SwiftUI projects
 UIAccessibility.post(notification: .announcement,
                      argument: "This is a VoiceOver message.")
 </code></pre>
@@ -669,13 +670,14 @@ This notification comes along with a vocalization including a sound like announc
 @IBAction func tapHere(_ sender: UIButton) {
         
     myLabel.accessibilityLabel = "This is a new label."
+    //This API can be used both in UIKit and SwiftUI projects
     UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged,
                          argument: myLabel)
 }
     
 //The first accessible element in the page is focused and vocalized with a sound like announcing a new page.
 @IBAction func clic(_ sender: UIButton) {
-        
+    //This API can be used both in UIKit and SwiftUI projects        
     UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
                          argument: nil)
 }
@@ -746,6 +748,7 @@ If we use the `accessibilityLanguage` attribute on a `UILabel`, it will be vocal
 <pre><code class="swift">
 @IBAction func tapHere(_ sender: UIButton) {
         
+    //accessibilityLanguage n'est pas encore disponible dans SwiftUI (seulement dans UIKit et AppKit)
     myLabel.accessibilityLanguage = "fr"
     myLabel.accessibilityLabel = "Ceci est un nouveau label. Merci."
 }

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -6,7 +6,7 @@ displayToc: true
 
 # iOS developer guide
 
-This guide aims to present the various iOS <abbr>SDK</abbr> accessibility options : through different categories, it explains how to use the accessibility attributes&nbsp;/ methods and provides links to the [`Apple official documentation`](https://developer.apple.com/documentation/uikit/accessibility).
+This guide aims to present the various iOS <abbr title="Software Development Kit">SDK</abbr> accessibility options: through different categories, it explains how to use the accessibility attributes&nbsp;/ methods and provides links to the `Apple official documentation` for both [`UIKit`](https://developer.apple.com/documentation/uikit/accessibility) and [`SwiftUI`](https://developer.apple.com/documentation/swiftui/accessibility-fundamentals).
 
 Code snippets are also available to show the different possible implementations {(**Swift&nbsp;5.7**, **Objective&nbsp;C**) + (**Xcode&nbsp;14**, **iOS&nbsp;16**)}.
 
@@ -99,6 +99,15 @@ func customTraits() {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+    //Add 'button' trait to some view
+    someView.accessibilityAddTraits(.isButton)
+
+    //Precise the other view is both a search field and selected
+    otherView.accessibilityAddTraits([.isSearchField, .isSelected])
+}
+</code></pre>
 </div>
 
 </div>
@@ -151,6 +160,14 @@ func changeTraits() {
     }
 }
 </code></pre>
+
+<pre><code class="swiftui">
+var body: some View {
+    //Remove the trait 'plays sound' to the view
+    aView.accessibilityRemoveTraits(.playsSound)
+}
+</code></pre>
+</div>
 
 </div>
 

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -911,6 +911,40 @@ override func viewDidAppear(_ animated: Bool) {
     }
 </code></pre>
 
+<pre><code class="swiftui">
+    var body: some View {
+        VStack {
+        
+            Text("Some text inside my container")
+                .accessibilityHidden(true) // Hide from Voice Over, by default is not
+        
+            Rectangle()
+                .fill(Color.yellow)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Precise this item is accessible
+            
+        
+            Rectangle()
+                .fill(Color.blue)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Precise this item is accessible
+            
+            Spacer()
+        }
+        .background(Color.green)
+        .frame(width: 500, height: 500)
+        
+        // Precise the container is accessible but children are not, i.e. accessibilityElement(children: .ignore)
+        .accessibilityElement()
+        
+        // Or precise this container contains accessible items to iterate one by one
+        .accessibilityElement(children: .contain)
+        
+        // Or precise this container contains accessible items to iterate as one single item
+        .accessibilityElement(children: .combine)
+    }
+</code></pre>
+
 </div>
 
 </div>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -877,7 +877,7 @@ override func viewDidAppear(_ animated: Bool) {
                                             y: 100.0,
                                             width: 40.0,
                                             height: 40.0)
-        let myParentView = UIView.init(frame: parentViewRect)
+        let myRedParentView = UIView.init(frame: parentViewRect)
         myRedParentView.backgroundColor = .red
         
         self.view.addSubview(myRedParentView)

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -919,6 +919,40 @@ override func viewDidAppear(_ animated: Bool) {
     }
 </code></pre>
 
+<pre><code class="swiftui">
+    var body: some View {
+        VStack {
+        
+            Text("Du texte dans un containeur")
+                .accessibilityHidden(true) // Cache de Voice Over, ne l'est pas par défaut
+        
+            Rectangle()
+                .fill(Color.yellow)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Cet item n'est pas accessible
+            
+        
+            Rectangle()
+                .fill(Color.blue)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Cet item n'est pas accessible
+            
+            Spacer()
+        }
+        .background(Color.green)
+        .frame(width: 500, height: 500)
+        
+        // Indique que le containeur est accessible mais pas les enfants (i.e. accessibilityElement(children: .ignore)
+        .accessibilityElement()
+        
+        // Ou indique que le containeur contient des élements accessibles sur lesquels itérer individuellement
+        .accessibilityElement(children: .contain)
+        
+        // Ou indique que le containeur contient des élements accessibles mais que c'est l'ensemble qu'il faut traiter
+        .accessibilityElement(children: .combine)
+    }
+</code></pre>
+
 </div>
 
 </div>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -282,6 +282,20 @@ class ChangeTextView: UIViewController {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+struct ChangeTextView: View {
+
+    var body: some View {
+        Text("Du texte")
+            .accessibilityLabel(Text("bonjour"))
+            .accessibilityHint(Text("Ceci est un commentaire supplémentaire."))
+            .accessibilityValue(Text("45 pour cent"))
+
+        // Il est possible d'utiliser directement du texte en tant que String plutôt que de passer par les objets de type Text
+    }
+}
+</code></pre>
+
 </div>
 
 </div>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -103,6 +103,15 @@ func customTraits() {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+    //Spécification d'une vue avec le trait 'bouton'
+    someView.accessibilityAddTraits(.isButton)
+
+    //Ajout des traits 'champs de recherche' et 'selectionné'
+    otherView.accessibilityAddTraits([.isSearchField, .isSelected])
+}
+</code></pre>
 </div>
 
 </div>
@@ -153,6 +162,13 @@ func changeTraits() {
     if (pageControl.accessibilityTraits.rawValue & UIAccessibilityTraits.header.rawValue == UIAccessibilityTraits.header.rawValue) {
         // Tâches à réaliser si le trait '.header' est présent...
     }
+}
+</code></pre>
+
+<pre><code class="swiftui">
+var body: some View {
+    //Suppression du trait 'joue un son'
+    aView.accessibilityRemoveTraits(.playsSound)
 }
 </code></pre>
 

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -584,6 +584,7 @@ UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
 </code></pre>
 
 <pre><code class="swift">
+//Cette API peut être utilisée autant pour des projets UIKit que pour des projets SwiftUI
 UIAccessibility.post(notification: .announcement,
                      argument: "Message pour la vocalisation.")
 </code></pre>
@@ -678,13 +679,14 @@ Le son utilisé pour notifier la modification est similaire à l'arrivée d'une 
 @IBAction func tapHere(_ sender: UIButton) {
         
     myLabel.accessibilityLabel = "Ceci est un nouveau label."
+    //Cette API peut être utilisée autant pour des projets UIKit que pour des projets SwiftUI
     UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged,
                          argument: myLabel)
 }
     
 //Le premier élément accessible de la page est sélectioné et vocalisé avec un son spécifique.
 @IBAction func clic(_ sender: UIButton) {
-        
+    //Cette API peut être utilisée autant pour des projets UIKit que pour des projets SwiftUI
     UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
                          argument: nil)
 }
@@ -755,7 +757,8 @@ Si on utilise l'attribut `accessibilityLanguage` sur un `UILabel`, alors celui-c
 
 <pre><code class="swift">
 @IBAction func tapHere(_ sender: UIButton) {
-        
+
+    //accessibilityLanguage is not available yet in SwiftUI (only UIKit and AppKit)        
     myLabel.accessibilityLanguage = "en"
     myLabel.accessibilityLabel = "This is a new label. Thank you."
 }


### PR DESCRIPTION
# Description

Today the web site does not contain code samples written in _SwiftUI_, I propose this pull request to bring more details about this framework.

# Topics to update if needed

- [ ] Grouping elements
- [ ] Reading order
- [ ] Custom content provider
- [ ] Focus on element
- [ ] Modify the focus area of VocieOver
- [ ] Modal view
- [ ] Text size
- [ ] Truncation hyphen
- [ ] Graphical elements size
- [ ] Large Content Viewer
- [ ] Continuous adjustable values
- [ ] Custom actions
- [ ] Custom rotor
- [ ] Accessibility options
- [ ] Navigation bar
- [ ] Speech synthesis
- [ ] Switch Control
- [ ] Vocalized application name

# Updated topics (or checked without updates needed)

- [x] Element trait (038126b84d343e604879388214658acfe28561fc)
- [x] Text alternatives (33621c0c3279a63530a561d2932e54894ad0214f)
- [x] Date, time and numbers
- [x] Trigger a vocalization
- [x] Notify a content change
- [x] Change the vocalization language
- [x] Hide elements (e62931638cf053d0a74d0f31ed1a6c87eb3a76ad)

# Fixed typos

- Bad variable name (46181fae18e21a5aa9f0f43ed3673c40851258f4)

cc @pya35 