### PR TITLE
Add SwiftUI examples in guidelines

### DIFF
--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -1774,6 +1774,52 @@ extension UIView {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+//The property wrapper AccessibilityFocusState allows to know is the element has the focus or not
+
+struct MyView: View {
+    @AccessibilityFocusState private var isElementFocused: Bool
+    @State private var myText = ""
+
+    var body: some View {
+        Form {
+            TextField("Text field", text: $myText)
+                .accessibilityFocused($isElementFocused)
+        }
+        .onChange(of: isElementFocused) { value in
+            print(value)
+        }
+    }
+}
+
+// It is also possible to move the focus automatically, e.g. here when a notification changed (https://developer.apple.com/documentation/swiftui/accessibilityfocusstate)
+
+struct CustomNotification: Equatable {
+    var text: String
+    var isPriority: Bool
+}
+
+struct ContentView: View {
+    @Binding var notification: CustomNotification?
+    @AccessibilityFocusState var isNotificationFocused: Bool
+
+    var body: some View {
+        VStack {
+            if let notification = self.notification {
+                Text(notification.text)
+                    .accessibilityFocused($isNotificationFocused)
+            }
+            Text("The main content for this view.")
+        }
+        .onChange(of: notification) { notification in
+            if (notification?.isPriority == true)  {
+                isNotificationFocused = true
+            }
+        }
+    }
+}
+</code></pre>
+
 </div>
 
 </div>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -1866,7 +1866,7 @@ struct ContentView: View {
      id="focusArea-Description"
      role="tabpanel">
      
-In case of dynamically modified element or component not inheriting from `UIView`, it is possible to modify the focus area of accessibility of this element, i.e. the area <span lang="en">VoiceOver</span> highlights when focusing an element.
+In case of dynamically modified element or component not inheriting from `UIView`, with UIKit, it is possible to modify the focus area of accessibility of this element, i.e. the area <span lang="en">VoiceOver</span> highlights when focusing an element.
 </div>
 <div class="tab-pane" id="focusArea-Details" role="tabpanel">
 

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -1223,6 +1223,23 @@ int indexSwitch = 1;
 }
 </code></pre>
 
+<pre><code class="swiftui">
+@State var isChecked = false 
+
+var body: some View {
+    HStack(){
+        Text("Some text: " + (isChecked ? "enabled : "disabled"))
+        Toggle("Test", isOn: $isChecked)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityHint("Some description text grouped with the button")
+    .accessibilityAction {
+        print("Action triggered on double tap")
+        isChecked.toggle()
+    }
+}
+</code></pre>
+
 </div>
 
 </div>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -6,9 +6,9 @@ displayToc: true
 
 # iOS developer guide
 
-This guide aims to present the various iOS <abbr>SDK</abbr> accessibility options : through different categories, it explains how to use the accessibility attributes&nbsp;/ methods and provides links to the [`Apple official documentation`](https://developer.apple.com/documentation/uikit/accessibility).
+This guide aims to present the various iOS <abbr title="Software Development Kit">SDK</abbr> accessibility options: through different categories, it explains how to use the accessibility attributes&nbsp;/&nbsp;methods and provides links to the `Apple official documentation` for both [`UIKit`](https://developer.apple.com/documentation/uikit/accessibility) and [`SwiftUI`](https://developer.apple.com/documentation/swiftui/accessibility-fundamentals).
 
-Code snippets are also available to show the different possible implementations {(**Swift&nbsp;5.7**, **Objective&nbsp;C**) + (**Xcode&nbsp;14**, **iOS&nbsp;16**)}.
+Code samples are available for **SwiftUI**, **UIKit using Swift&nbsp;5.7** and **UIKit with Objective&nbsp;C** using {**Xcode&nbsp;14** ; **iOS&nbsp;16**},
 
 <br><br>
 
@@ -99,6 +99,36 @@ func customTraits() {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+    //Add 'button' trait to some view
+    someView.accessibilityAddTraits(.isButton)
+
+    //Add traits for 'search field' and 'selected state'
+    otherView.accessibilityAddTraits([.isSearchField, .isSelected])
+
+    //Add traits 'is header'
+    view.accessibilityAddTraits(.isHeader)
+
+    //The element is adjustable
+    antoherView
+        .accessibilityElement()
+        .accessibilityValue(Text(index))
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                guard selectedIndex < 5 else { break }
+                index += 1
+            case .decrement:
+                guard selectedIndex > 0 else { break }
+                index -= 1
+            @unknown default:
+                break
+            }
+        }
+}
+</code></pre>
+
 </div>
 
 </div>
@@ -152,12 +182,21 @@ func changeTraits() {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+    //Remove the trait 'plays sound' to the view
+    some.accessibilityRemoveTraits(.playsSound)
+}
+</code></pre>
+
 </div>
 
 </div>
 <div class="tab-pane" id="TraitElt-Links" role="tabpanel">
 
 - [`accessibilityTraits`](https://developer.apple.com/documentation/objectivec/nsobject/1615202-accessibilitytraits)
+- [`accessibilityTraits`](https://developer.apple.com/documentation/swiftui/view/accessibilityaddtraits(_:))
+- [`accessibilityAdjustableAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityadjustableaction(_:)/)
 </div>
 </div>
 <br><br>
@@ -260,19 +299,38 @@ class ChangeTextView: UIViewController {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+struct ChangeTextView: View {
+
+    var body: some View {
+        Text("Some text")
+            .accessibilityLabel(Text("hello"))
+            .accessibilityHint(Text("This is an added comment."))
+            .accessibilityValue(Text("45 per cent"))
+
+        // You can use also raw strings instead of Text views
+    }
+}
+</code></pre>
+
 </div>
 
 </div>
 <div class="tab-pane" id="textAlt-Links" role="tabpanel"> 
 
-- [`accessibilityLabel`](https://developer.apple.com/documentation/objectivec/nsobject/1615181-accessibilitylabel)
+- [`accessibilityHint (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-- [`accessibilityValue`](https://developer.apple.com/documentation/objectivec/nsobject/1615117-accessibilityvalue)
+- [`accessibilityValue (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615117-accessibilityvalue)
 
-- [`accessibilityHint`](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
+- [`accessibilityHint (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
+
+- [`accessibilityLabel (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-5f0zj)
+
+- [`accessibilityValue (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityvalue(_:)-2bwuz)
+
+- [`accessibilityHint (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityhint(_:)-3i2vu)
 
 - [Writing Great Accessibility Labels](../wwdc/2019/#writing-great-accessibility-labels)
-    
 </div>
 </div>
 <br><br>
@@ -318,7 +376,6 @@ Using VoiceOver for reading date, time and numbers may become rapidly a headache
 <div class="tab-pane" id="format-DateTime" role="tabpanel">
 
 The rendering isn't natural if the date or time data are imported text in a `label`.
-
 
 ![](../../images/iOSdev/DateHeureNombres_11.png)
 <br>Incoming data must be formatted to obtain a natural and understandable descriptive vocalization.
@@ -377,6 +434,25 @@ The rendering isn't natural if the date or time data are imported text in a `lab
                                                                            unitsStyle: .spellOut)
 </code></pre>
 
+<pre><code class="swiftui">
+    let dateFormatter: DateFormatter = {
+        let formatter = Dateformatter()
+        formatter.dateFormat = "dd/MM/yyyy HH:mm"
+    }()
+
+    let longDateFormatter: DateFormatter = {
+        let formatter = Dateformatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .medium
+        return formatter
+    }() 
+
+    var body: some View {
+            Text(dateFormatter.string(from: Date()))
+                .accessibiltyLabel(Text("Date"))
+                .accessibilityValue(Text(longDateFormatter.string(from: Date())))
+    }
+</code></pre>
 </div>
 
 </div>
@@ -410,6 +486,15 @@ If a number is imported as is in a `label`text, the vocalization will be made on
                                                            
     numberLabel.accessibilityLabel = NumberFormatter.localizedString(from: numberValue,
                                                                      number: .spellOut)
+</code></pre>
+
+<pre><code class="swiftui">
+    let numberValue = NSNumber(value: 54038921.7)
+
+    var body: some View {
+        Text(NumberFormatter.localizedString(from: numberValue, number: .decimal))
+            .accessibilityLabel(NumberFormatter.localizedString(from: numberValue, number: .spellOut))
+    }
 </code></pre>
 
 </div>
@@ -548,6 +633,12 @@ UIAccessibility.post(notification: .announcement,
                      argument: "This is a VoiceOver message.")
 </code></pre>
 
+<pre><code class="swiftui">
+// Can be placed in an .onAppear{} or .task{} call, maybe delayed in main Dispatch Queue
+UIAccessibility.post(notification: .announcement,
+                     argument: "This is a VoiceOver message.")
+</code></pre>
+
 </div>
 
 </div>
@@ -644,7 +735,7 @@ This notification comes along with a vocalization including a sound like announc
     
 //The first accessible element in the page is focused and vocalized with a sound like announcing a new page.
 @IBAction func clic(_ sender: UIButton) {
-        
+    //This API can be used both in UIKit and SwiftUI projects         
     UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
                          argument: nil)
 }
@@ -714,7 +805,7 @@ If we use the `accessibilityLanguage` attribute on a `UILabel`, it will be vocal
 
 <pre><code class="swift">
 @IBAction func tapHere(_ sender: UIButton) {
-        
+    //accessibilityLanguage is not available yet in SwiftUI (only UIKit and AppKit)        
     myLabel.accessibilityLanguage = "fr"
     myLabel.accessibilityLabel = "Ceci est un nouveau label. Merci."
 }
@@ -877,16 +968,56 @@ override func viewDidAppear(_ animated: Bool) {
     }
 </code></pre>
 
+<pre><code class="swiftui">
+    var body: some View {
+        VStack {
+        
+            Text("Some text inside my container")
+                .accessibilityHidden(true) // Hide from Voice Over, by default is not
+        
+            Rectangle()
+                .fill(Color.yellow)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Precise this item is accessible
+            
+            Rectangle()
+                .fill(Color.blue)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Precise this item is accessible
+            
+            Spacer()
+        }
+        .background(Color.green)
+        .frame(width: 500, height: 500)
+        
+        // Precise the container is accessible but children are not, i.e. accessibilityElement(children: .ignore)
+        .accessibilityElement()
+        
+        // Or precise this container contains accessible items to iterate one by one
+        .accessibilityElement(children: .contain)
+        
+        // Or precise this container contains accessible items to iterate as one single item
+        .accessibilityElement(children: .combine)
+    }
+</code></pre>
+
 </div>
 
 </div>
 <div class="tab-pane" id="hideElts-Links" role="tabpanel">
 
-- [`isAccessibilityElement`](https://developer.apple.com/documentation/objectivec/nsobject/1615141-isaccessibilityelement)
+- [`isAccessibilityElement (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615141-isaccessibilityelement)
 
-- [`accessibilityElementsHidden`](https://developer.apple.com/documentation/objectivec/nsobject/1615080-accessibilityelementshidden)
+- [`accessibilityElementsHidden (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615080-accessibilityelementshidden)
 
-- [`accessibilityViewIsModal`](https://developer.apple.com/documentation/objectivec/nsobject/1615089-accessibilityviewismodal)
+- [`accessibilityViewIsModal (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615089-accessibilityviewismodal)
+
+- [`accessibilityElement (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityelement(children:))
+
+- [`accessibilityHidden (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityhidden(_:))
+
+- [`isModal`](https://developer.apple.com/documentation/swiftui/accessibilitytraits/ismodal)
+
 </div>
 </div>
 <br><br>
@@ -981,6 +1112,19 @@ Create your wrapper as an accessible element after unticking the `Accessibility 
         self.view.addSubview(wrap)
     }
 }
+</code></pre>
+
+<pre><code class="swiftui">
+    @State private var isChecked = false // Default value for the switch
+    
+    var body: some View {
+        HStack(){
+            Text("Descriptive text")
+            Toggle("Test", isOn: $isChecked)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Descriptive text grouped with the button")
+    }
 </code></pre>
 
 </div>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -2261,6 +2261,57 @@ Since iOS7, it is possible to make the text size dynamic according to the device
     fontHeadline.font = fontHeadMetrics.scaledFont(for: fontHead!)
 </code></pre>
 
+<pre><code class="swftui">
+var body: some View {
+    Text("Some text")
+        // System font
+        .font(.headline)
+        // Custom font
+        .font(Font.custom("MyFont", size: 18))
+        // Custom font with relative definition
+        .font(Font.custom("MyFont", size: 18, relativeTo: .title))
+    }
+}
+
+// SwiftUI allows to know is the text size has changed and permits to extend ContentSizeCategory to get the current size
+
+// Property to get the current size
+@Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
+
+// Extension to define to know if the current etxt size is an accessible size or just a large size
+extension ContentSizeCategory {
+    
+    var isAccessible: Bool {
+        switch self {
+        case .accessibilityExtraExtraExtraLarge, // 310 %
+             .accessibilityExtraExtraLarge, // 275 %
+             .accessibilityExtraLarge, // 235%
+             .accessibilityLarge, // 190 %
+             .accessibilityMedium: // 160 %
+            return true
+        default:
+            return false
+        }
+    }
+    
+    var isLargeTextUsed: Bool {
+        switch self {
+        case .accessibilityExtraExtraExtraLarge, // 310 %
+             .accessibilityExtraExtraLarge, // 275 %
+             .accessibilityExtraLarge, // 235 %
+             .accessibilityLarge, // 190 %
+             .accessibilityMedium, // 160 %
+             .extraExtraExtraLarge, // 135 %
+             .extraExtraLarge, // 120%
+             .extraLarge: // 110 %
+            return true
+        default:
+            return false
+        }
+    }
+}
+</code></pre>
+
 </div>
 
 <br>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -1436,6 +1436,30 @@ Two views are created containing the numbers to be spelled out in a specific ord
     }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+
+    // The higher the priority is, the sooner the items will be vocalized
+    HStack {
+        VStack { // Natural order of the container will be used
+            Text("1") // Rank 1
+            Text("2") // Rank 2
+            Text("3") // Rank 3
+        }.accessibilitySortPriority(1000) // 1st group to be vocalized
+        VStack {
+            Text("4").accessibilitySortPriority(900) // Rank 4
+            Text("5").accessibilitySortPriority(400) // Rank 9
+            Text("6").accessibilitySortPriority(700) // Rank 6
+        }
+        VStack {
+            Text("7").accessibilitySortPriority(800) // Rank 5
+            Text("8").accessibilitySortPriority(600) // Rank 7
+            Text("9").accessibilitySortPriority(500) // Rank 8
+        }
+    }.accessibilityElement(children: .contain)
+}
+<code></pre>
+
 </div>
 
 </div>

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -934,7 +934,7 @@ override func viewDidAppear(_ animated: Bool) {
                                             y: 100.0,
                                             width: 40.0,
                                             height: 40.0)
-        let myParentView = UIView.init(frame: parentViewRect)
+        let myRedParentView = UIView.init(frame: parentViewRect)
         myRedParentView.backgroundColor = .red
         
         self.view.addSubview(myRedParentView)

--- a/src/en/mobile/ios/development.md
+++ b/src/en/mobile/ios/development.md
@@ -1527,6 +1527,8 @@ To implement this functionality, it's mandatory to:
 
 - define each and every **AXCustomContent** element with its `value` and the kind of family this value belongs to (`label`).
 
+About SwiftUI, this feature is much simple to use without needing use of **AXCustomContentProvider** neither import of_Accessibility_ API.
+
 The `More`&nbsp;`Content` **rotor item** is the only means to get these information by vocalizing every `AXCustomContent` element thanks to a one finger vertical swipe like the [continuous adjustable values](#continuous-adjustable-values) or the [custom actions](#custom-actions).
 </div>
 <div class="tab-pane" id="CuCoPro-Example" role="tabpanel">
@@ -1628,6 +1630,17 @@ class ViewController: UIViewController {
 
         myView.accessibilityCustomContent = [lastModified, items, type]
     }
+}
+</code></pre>
+
+<pre><code class="swiftui">
+var body: some View {
+    Image(...)
+        .accessibilityLabel("Orange logo")
+        .accessibilityHint("use the rotor item entitled more content to get additional information")            
+        .accessibilityCustomContent(AccessibilityCustomContentKey("date of creation"), Text("1988"))
+        .accessibilityCustomContent(AccessibilityCustomContentKey("registered office location"), Text("paris"))
+        .accessibilityCustomContent(AccessibilityCustomContentKey("type of company"), Text("telecommunications"))
 }
 </code></pre>
 

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -1547,7 +1547,7 @@ On peut aussi envisager l'implémentation de cette fonctionnalité dans des list
 </div>
 <div class="tab-pane" id="CuCoPro-Details" role="tabpanel">
 
-Pour utiliser cette fonctionnalité, il est impératif de&nbsp;:
+Pour utiliser cette fonctionnalité avec UIKit, il est impératif de&nbsp;:
 
 - se conformer au protocole **AXCustomContentProvider**,
 
@@ -1556,6 +1556,7 @@ Pour utiliser cette fonctionnalité, il est impératif de&nbsp;:
 - définir chaque élément **AXCustomContent** avec sa caractéristique (`value`) ainsi que la famille à laquelle elle appartient (`label`).
 
 
+Concernant SwiftUI, l'usage est bien plus simple sans utilisation de **AXCustomContentProvider** ni de l'API _Accessibility_.
 
 L'accès à ces informations se fait en **utilisant le rotor** qui contiendra alors un item **`Plus`&nbsp;`de`&nbsp;`contenus`** qui permettra de vocaliser chaque `AXCustomContent` par un **balayage vertical avec un doigt** comme pour les [valeurs continûment ajustables](#valeurs-continument-ajustables) ou les [actions personnalisées](#actions-personnalisees).
 </div>
@@ -1604,6 +1605,16 @@ class MyCustomView: UIImageView, AXCustomContentProvider {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+    Image(...)
+        .accessibilityLabel("logo Orange")
+        .accessibilityHint("utiliser l'élément du rotor intitulé plus de contenus pour obtenir des informations complémentaires")            
+        .accessibilityCustomContent(AccessibilityCustomContentKey("date de création"), Text("1988"))
+        .accessibilityCustomContent(AccessibilityCustomContentKey("siège social"), Text("paris"))
+        .accessibilityCustomContent(AccessibilityCustomContentKey("type de société"), Text("télécommunications"))
+}
+</code></pre>
 </div>
 
 <br>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -10,9 +10,9 @@ Ce guide a pour objectif de présenter les différentes notions d’accessibilit
 
 - des explications détaillées concernant les attributs et méthodes d'accessibilité,
 
-- des exemples de code en **SwiftUI**, **Swift&nbsp;5.7** et en **Objective&nbsp;C** sous {**Xcode&nbsp;14** ; **iOS&nbsp;16**},
+- des exemples de code en **SwiftUI**, **UIKit avec Swift&nbsp;5.7** et en **UIKit avec Objective&nbsp;C** sous {**Xcode&nbsp;14** ; **iOS&nbsp;16**},
 
-- des liens vers la [`documentation officielle Apple`](https://developer.apple.com/documentation/uikit/accessibility).
+- des liens vers la documentation officielle [`UIKit`](https://developer.apple.com/documentation/uikit/accessibility) et [`SwiftUI`](https://developer.apple.com/documentation/swiftui/accessibility-fundamentals).
 
 <br><br>
 
@@ -104,25 +104,33 @@ func customTraits() {
 </code></pre>
 
 <pre><code class="swiftui">
-//Spécification d'un élément avec le trait ’ajustable’.
-    .accessibilityElement()
-    .accessibilityValue(Text(index))
-    .accessibilityAdjustableAction { direction in
-        switch direction {
-        case .increment:
-            guard selectedIndex < 5 else { break }
-            index += 1
-        case .decrement:
-            guard selectedIndex > 0 else { break }
-            index -= 1
-        @unknown default:
-            break
+var body: some View {
+    //Spécification d'une vue avec le trait 'bouton'
+    someView.accessibilityAddTraits(.isButton)
+
+    //Ajout des traits 'champs de recherche' et 'selectionné'
+    otherView.accessibilityAddTraits([.isSearchField, .isSelected])
+
+    //Ajout d'un trait 'en-tête'
+    view.accessibilityAddTraits(.isHeader)
+
+    //Spécification d'un élément avec le trait ’ajustable’.
+    anotherView
+        .accessibilityElement()
+        .accessibilityValue(Text(index))
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                guard selectedIndex < 5 else { break }
+                index += 1
+            case .decrement:
+                guard selectedIndex > 0 else { break }
+                index -= 1
+            @unknown default:
+                break
+            }
         }
-    }
-
-//Ajout d'un en-tête. 
-    defaultHeaderViewCell.accessibilityaddTraits(.isHeader)
-
+}
 </code></pre>
 
 </div>
@@ -179,17 +187,10 @@ func changeTraits() {
 </code></pre>
 
 <pre><code class="swiftui">
-     
-    //Ajouts de traits au contenu existant.
-    pageControl.accessibilityAddTraits(.isButton)
-    pageControl.accessibilityAddTraits(.isButton, .isheader) //Many traits.
-
-    //Suppression d'un trait.
-    pageControl.accessibilityRemoveTraits(.header)
-        
-    //Vérification de l'existence d'un trait.
-    to be completed
-
+var body: some View {
+    //Suppression du trait 'joue un son'
+    aView.accessibilityRemoveTraits(.playsSound)
+}
 </code></pre>
 
 </div>
@@ -197,8 +198,9 @@ func changeTraits() {
 </div>
 <div class="tab-pane" id="TraitElt-Links" role="tabpanel" >
 
-- [`accessibilityTraits`](https://developer.apple.com/documentation/swiftui/view/accessibilityaddtraits(_:))
-- [`accessibilityAdjustableAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityadjustableaction(_:)/)
+- [`accessibilityTraits (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615202-accessibilitytraits)
+- [`accessibilityTraits (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityaddtraits(_:))
+- [`accessibilityAdjustableAction (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityadjustableaction(_:)/)
 </div>
 </div>
 <br><br>
@@ -304,10 +306,17 @@ class ChangeTextView: UIViewController {
 </code></pre>
 
 <pre><code class="swiftui">
-Button ("MyButton") {
+struct ChangeTextView: View {
+
+    var body: some View {
+        Text("Du texte")
+            .accessibilityLabel(Text("bonjour"))
+            .accessibilityHint(Text("Ceci est un commentaire supplémentaire."))
+            .accessibilityValue(Text("45 pour cent"))
+
+        // Il est possible d'utiliser directement du texte en tant que String plutôt que de passer par les objets de type Text
+    }
 }
-.accessibilityLabel("Télécharger")
-.accessibilityHint("Téléchargement de toutes les pièces jointes")
 </code></pre>
 
 </div>
@@ -315,11 +324,17 @@ Button ("MyButton") {
 </div>
 <div class="tab-pane" id="textAlt-Links" role="tabpanel" > 
 
-- [`accessibilityLabel`](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-5f0zj)
+- [`accessibilityHint (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-- [`accessibilityValue`](https://developer.apple.com/documentation/swiftui/view/accessibilityvalue(_:)-2bwuz)
+- [`accessibilityValue (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615117-accessibilityvalue)
 
-- [`accessibilityHint`](https://developer.apple.com/documentation/swiftui/view/accessibilityhint(_:)-3i2vu )
+- [`accessibilityHint (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
+
+- [`accessibilityLabel (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-5f0zj)
+
+- [`accessibilityValue (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityvalue(_:)-2bwuz)
+
+- [`accessibilityHint (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityhint(_:)-3i2vu)
 
 - [La&nbsp;bonne&nbsp;rédaction&nbsp;des&nbsp;labels](../wwdc/2019#la-bonne-redaction-des-labels)
 </div>
@@ -426,23 +441,23 @@ Il faut absolument formater les données en entrée pour obtenir une vocalisatio
 </code></pre>
 
 <pre><code class="swiftui">
-let dateFormatter: DateFormatter = {
-    let formatter = Dateformatter()
-    formatter.dateFormat = "dd/MM/yyyy HH:mm"
-}()
+    let dateFormatter: DateFormatter = {
+        let formatter = Dateformatter()
+        formatter.dateFormat = "dd/MM/yyyy HH:mm"
+    }()
 
-let longDateFormatter: DateFormatter = {
-    let formatter = Dateformatter()
-    formatter.dateStyle = .long
-    formatter.timeStyle = .medium
-    return formatter
-}() 
+    let longDateFormatter: DateFormatter = {
+        let formatter = Dateformatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .medium
+        return formatter
+    }() 
 
-var body: some View {
-        Text(dateFormatter.string(from: Date()))
-            .accessibiltyLabel(Text("Date"))
-            .accessibilityValue(Text(longDateFormatter.string(from: Date())))
-}
+    var body: some View {
+            Text(dateFormatter.string(from: Date()))
+                .accessibiltyLabel(Text("Date"))
+                .accessibilityValue(Text(longDateFormatter.string(from: Date())))
+    }
 </code></pre>
 
 </div>
@@ -482,11 +497,12 @@ Comme pour les date et heure, il faut formater la donnée en entrée pour qu'ell
 </code></pre>
 
 <pre><code class="swiftui">
-let numberValue = NSNumber(value: 54038921.7)
-        
-Text(NumberFormatter.localizedString(from: numberValue, number: .decimal))
-    .accessibilityLabel(NumberFormatter.localizedString(from: numberValue,
-                                                        number: .spellOut))
+    let numberValue = NSNumber(value: 54038921.7)
+
+    var body: some View {
+        Text(NumberFormatter.localizedString(from: numberValue, number: .decimal))
+            .accessibilityLabel(NumberFormatter.localizedString(from: numberValue, number: .spellOut))
+    }
 </code></pre>
 </div>
 
@@ -633,6 +649,7 @@ UIAccessibility.post(notification: .announcement,
 </code></pre>
 
 <pre><code class="swiftui">
+// À appeler par exemple dans un .onAppear{} ou .task{}, avec un délai dans la main Dispatch Queue
 UIAccessibility.post(notification: .announcement,
                      argument: "Message pour la vocalisation.")
 </code></pre>
@@ -715,7 +732,7 @@ Le son utilisé pour notifier la modification est similaire à l'arrivée d'une 
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, myLabel);
 }
 
-//Le premier élément accessible de la page est sélectioné et vocalisé avec un son spécifique.
+//Le premier élément accessible de la page est sélectionné et vocalisé avec un son spécifique.
 - (IBAction)clic:(UIButton *)sender {
     
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
@@ -734,6 +751,7 @@ Le son utilisé pour notifier la modification est similaire à l'arrivée d'une 
 //Le premier élément accessible de la page est sélectionné et vocalisé avec un son spécifique.
 
 @IBAction func clic(_ sender: UIButton) {
+    //Cette API peut être utilisée autant pour des projets UIKit que pour des projets SwiftUI
     UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
                          argument: nil)
 }
@@ -808,7 +826,7 @@ Si on utilise l'attribut `accessibilityLanguage` sur un `UILabel`, alors celui-c
 
 <pre><code class="swift">
 @IBAction func tapHere(_ sender: UIButton) {
-        
+    //accessibilityLanguage n'est pas encore disponible dans SwiftUI (seulement UIKit et AppKit)                
     myLabel.accessibilityLanguage = "en"
     myLabel.accessibilityLabel = "This is a new label. Thank you."
 }
@@ -974,16 +992,36 @@ override func viewDidAppear(_ animated: Bool) {
 </code></pre>
 
 <pre><code class="swiftui">
-//Masquage d'une image décorative, en conservant les autres traits accessibles
-//comme un bouton, un lien, un label, etc. qui seront vocalisés par VoiceOver
-   
-    Image(decorative: "monImage")
-
-// Masquage de tous les traits associés à l'image (plus rien ne sera vocalisé par Voice Over)
-     
-     Image(decorative: "monImage")
-        .accessibilityHidden(true)
-
+    var body: some View {
+        VStack {
+        
+            Text("Du texte dans un containeur")
+                .accessibilityHidden(true) // Cache de Voice Over, ne l'est pas par défaut
+        
+            Rectangle()
+                .fill(Color.yellow)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Cet item n'est pas accessible
+        
+            Rectangle()
+                .fill(Color.blue)
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(false) // Cet item n'est pas accessible
+            
+            Spacer()
+        }
+        .background(Color.green)
+        .frame(width: 500, height: 500)
+        
+        // Indique que le containeur est accessible mais pas les enfants (i.e. accessibilityElement(children: .ignore)
+        .accessibilityElement()
+        
+        // Ou indique que le containeur contient des élements accessibles sur lesquels itérer individuellement
+        .accessibilityElement(children: .contain)
+        
+        // Ou indique que le containeur contient des élements accessibles mais que c'est l'ensemble qu'il faut traiter
+        .accessibilityElement(children: .combine)
+    }
 </code></pre>
 
 </div>
@@ -991,13 +1029,18 @@ override func viewDidAppear(_ animated: Bool) {
 </div>
 <div class="tab-pane" id="hideElts-Links" role="tabpanel">
 
-- [`isAccessibilityElement`](https://developer.apple.com/documentation/objectivec/nsobject/1615141-isaccessibilityelement)
+- [`isAccessibilityElement (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615141-isaccessibilityelement)
 
-- [`accessibilityElement`](https://developer.apple.com/documentation/swiftui/view/accessibilityelement(children:))
+- [`accessibilityElementsHidden (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615080-accessibilityelementshidden)
 
-- [`accessibilityHidden`](https://developer.apple.com/documentation/swiftui/view/accessibilityhidden(_:)/)
+- [`accessibilityViewIsModal (UIKit)`](https://developer.apple.com/documentation/objectivec/nsobject/1615089-accessibilityviewismodal)
+
+- [`accessibilityElement (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityelement(children:))
+
+- [`accessibilityHidden (SwiftUI)`](https://developer.apple.com/documentation/swiftui/view/accessibilityhidden(_:))
 
 - [`isModal`](https://developer.apple.com/documentation/swiftui/accessibilitytraits/ismodal)
+
 </div>
 </div>
 <br><br>
@@ -1162,16 +1205,13 @@ int indexSwitch = 1;
     let indexLabel = 0
     let indexSwitch = 1
     
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
     
-    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
     
     convenience init(with label: UILabel,and aSwitch: UISwitch) {
         
@@ -1186,11 +1226,9 @@ int indexSwitch = 1;
         let switchValue = (aSwitch.isOn) ? "activé" : "désactivé"
         
         self.isAccessibilityElement = true
-        self.accessibilityLabel = "le contrôl
-        e est " + switchValue.description
+        self.accessibilityLabel = "le contrôle est " + switchValue.description
         self.accessibilityHint = "tapez deux fois pour changer sa valeur."
     }
-    
     
     //Fonction appelée par le système quand un double tap est réalisé sur l'élément sélectionné pour l'activer.
     override func accessibilityActivate() -> Bool {

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -2281,6 +2281,59 @@ Depuis iOS7, il est possible de modifier dynamiquement la taille des textes d'un
     fontHeadline.font = fontHeadMetrics.scaledFont(for: fontHead!)
 </code></pre>
 
+<pre><code class="swftui">
+var body: some View {
+    Text("Un peu de texte")
+        // Police système
+        .font(.headline)
+        // Police customisée
+        .font(Font.custom("MyFont", size: 18))
+        // Ou alors une police customisée de définition relative
+        .font(Font.custom("MyFont", size: 18, relativeTo: .title))
+    }
+}
+
+// SwiftUI permet également de savoir si la taille de texte a changé, et permet d'étendre le composant
+// ContentSizeCategory afin de savoir quelle taille de texte est appliquée
+
+// Propriété pour accéder à la taille de texte utilisée
+@Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
+
+// Une extension à définir pour savoir si la taille de etxte est une des tailles "accessibles"
+// ou une grosse taille de manière plus générale
+extension ContentSizeCategory {
+    
+    var isAccessible: Bool {
+        switch self {
+        case .accessibilityExtraExtraExtraLarge, // 310 %
+             .accessibilityExtraExtraLarge, // 275 %
+             .accessibilityExtraLarge, // 235%
+             .accessibilityLarge, // 190 %
+             .accessibilityMedium: // 160 %
+            return true
+        default:
+            return false
+        }
+    }
+    
+    var isLargeTextUsed: Bool {
+        switch self {
+        case .accessibilityExtraExtraExtraLarge, // 310 %
+             .accessibilityExtraExtraLarge, // 275 %
+             .accessibilityExtraLarge, // 235 %
+             .accessibilityLarge, // 190 %
+             .accessibilityMedium, // 160 %
+             .extraExtraExtraLarge, // 135 %
+             .extraExtraLarge, // 120%
+             .extraLarge: // 110 %
+            return true
+        default:
+            return false
+        }
+    }
+}
+</code></pre>
+
 </div>
 
 <br>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -1245,6 +1245,23 @@ int indexSwitch = 1;
 }
 </code></pre>
 
+<pre><code class="swiftui">
+@State var isChecked = false 
+
+var body: some View {
+    HStack(){
+        Text("Texte descriptif : " + (isChecked ? "activé" : "désactivé"))
+        Toggle("Test", isOn: $isChecked)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityHint("Texte descriptif groupé avec le bouton")
+    .accessibilityAction {
+        print("Action déclenchée au double tap")
+        isChecked.toggle()
+    }
+}
+</code></pre>
+
 </div>
 
 </div>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -1465,6 +1465,29 @@ On crée deux vues au sein desquelles on incorpore les chiffres qu'on souhaite v
     }
 </code></pre>
 
+<pre><code class="swiftui">
+var body: some View {
+
+    // Plus la priorité est elevée, plus tôt sera vocalisé l'élément
+    HStack {
+        VStack { // On suit l'ordre naturel du containeur
+            Text("1") // Position 1
+            Text("2") // Position 2
+            Text("3") // Position 3
+        }.accessibilitySortPriority(1000) // La vocalisation commence ici
+        VStack {
+            Text("4").accessibilitySortPriority(900) // Position 4
+            Text("5").accessibilitySortPriority(400) // Position 9
+            Text("6").accessibilitySortPriority(700) // Position 6
+        }
+        VStack {
+            Text("7").accessibilitySortPriority(800) // Position 5
+            Text("8").accessibilitySortPriority(600) // Position 7
+            Text("9").accessibilitySortPriority(500) // Position 8
+        }
+    }.accessibilityElement(children: .contain)
+}
+<code></pre>
 </div>
 
 </div>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -1895,7 +1895,7 @@ struct ContentView: View {
      id="focusArea-Description"
      role="tabpanel">
      
-Dans le cas d’objet modifié dynamiquement ou d’élément ne dérivant pas de `UIView`, il est possible de déterminer la zone géographique d’accessibilité de cet élément, c’est-à-dire la zone que <span lang="en">VoiceOver</span> met en surbrillance lors du focus.
+Dans le cas d’objet modifié dynamiquement ou d’élément ne dérivant pas de `UIView`, avec UIKit, il est possible de déterminer la zone géographique d’accessibilité de cet élément, c’est-à-dire la zone que <span lang="en">VoiceOver</span> met en surbrillance lors du focus.
 </div>
 <div class="tab-pane" id="focusArea-Details" role="tabpanel">
 

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -1807,13 +1807,13 @@ struct MyView: View {
     @State private var monTexte = ""
 
     var body: some View {
-            Form {
-                TextField("Champ d'édition", text: $monTexte)
-                    .accessibilityFocused($isElementFocused)
-            }
-            .onChange(of: isElementFocused) { value in
-                print(value)
-            }
+        Form {
+            TextField("Champ d'édition", text: $monTexte)
+                .accessibilityFocused($isElementFocused)
+        }
+        .onChange(of: isElementFocused) { value in
+            print(value)
+        }
     }
 }
 
@@ -1835,7 +1835,7 @@ struct ContentView: View {
                 Text(notification.text)
                     .accessibilityFocused($isNotificationFocused)
             }
-            Text("The main content for this view.")
+            Text("Un peu de texte pour cette vue.")
         }
         .onChange(of: notification) { notification in
             if (notification?.isPriority == true)  {
@@ -1844,7 +1844,6 @@ struct ContentView: View {
         }
     }
 }
-
 </code></pre>
 
 </div>

--- a/src/fr/mobile/ios/developpement.md
+++ b/src/fr/mobile/ios/developpement.md
@@ -10,7 +10,7 @@ Ce guide a pour objectif de présenter les différentes notions d’accessibilit
 
 - des explications détaillées concernant les attributs et méthodes d'accessibilité,
 
-- des exemples de code en **Swift&nbsp;5.7** et en **Objective&nbsp;C** sous {**Xcode&nbsp;14** ; **iOS&nbsp;16**},
+- des exemples de code en **SwiftUI**, **Swift&nbsp;5.7** et en **Objective&nbsp;C** sous {**Xcode&nbsp;14** ; **iOS&nbsp;16**},
 
 - des liens vers la [`documentation officielle Apple`](https://developer.apple.com/documentation/uikit/accessibility).
 
@@ -51,7 +51,7 @@ Ce guide a pour objectif de présenter les différentes notions d’accessibilit
            data-bs-toggle="tab" 
            href="#TraitElt-Links" 
            role="tab" 
-           aria-selected="false">Lien</a>
+           aria-selected="false">Liens</a>
     </li>
 </ul><div class="tab-content">
 <div class="tab-pane show active"
@@ -103,9 +103,31 @@ func customTraits() {
 }
 </code></pre>
 
-</div>
+<pre><code class="swiftui">
+//Spécification d'un élément avec le trait ’ajustable’.
+    .accessibilityElement()
+    .accessibilityValue(Text(index))
+    .accessibilityAdjustableAction { direction in
+        switch direction {
+        case .increment:
+            guard selectedIndex < 5 else { break }
+            index += 1
+        case .decrement:
+            guard selectedIndex > 0 else { break }
+            index -= 1
+        @unknown default:
+            break
+        }
+    }
+
+//Ajout d'un en-tête. 
+    defaultHeaderViewCell.accessibilityaddTraits(.isHeader)
+
+</code></pre>
 
 </div>
+</div>
+
 <div class="tab-pane" id="TraitElt-BasicOperations" role="tabpanel" >
 
 L'attribut `accessibilityTrait` est en réalité un `bitmask` pour lequel chaque élément pris individuellement peut prendre une valeur spécifique.
@@ -156,12 +178,27 @@ func changeTraits() {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+     
+    //Ajouts de traits au contenu existant.
+    pageControl.accessibilityAddTraits(.isButton)
+    pageControl.accessibilityAddTraits(.isButton, .isheader) //Many traits.
+
+    //Suppression d'un trait.
+    pageControl.accessibilityRemoveTraits(.header)
+        
+    //Vérification de l'existence d'un trait.
+    to be completed
+
+</code></pre>
+
 </div>
 
 </div>
 <div class="tab-pane" id="TraitElt-Links" role="tabpanel" >
 
-- [`accessibilityTraits`](https://developer.apple.com/documentation/objectivec/nsobject/1615202-accessibilitytraits)
+- [`accessibilityTraits`](https://developer.apple.com/documentation/swiftui/view/accessibilityaddtraits(_:))
+- [`accessibilityAdjustableAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityadjustableaction(_:)/)
 </div>
 </div>
 <br><br>
@@ -266,16 +303,23 @@ class ChangeTextView: UIViewController {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+Button ("MyButton") {
+}
+.accessibilityLabel("Télécharger")
+.accessibilityHint("Téléchargement de toutes les pièces jointes")
+</code></pre>
+
 </div>
 
 </div>
 <div class="tab-pane" id="textAlt-Links" role="tabpanel" > 
 
-- [`accessibilityLabel`](https://developer.apple.com/documentation/objectivec/nsobject/1615181-accessibilitylabel)
+- [`accessibilityLabel`](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-5f0zj)
 
-- [`accessibilityValue`](https://developer.apple.com/documentation/objectivec/nsobject/1615117-accessibilityvalue)
+- [`accessibilityValue`](https://developer.apple.com/documentation/swiftui/view/accessibilityvalue(_:)-2bwuz)
 
-- [`accessibilityHint`](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
+- [`accessibilityHint`](https://developer.apple.com/documentation/swiftui/view/accessibilityhint(_:)-3i2vu )
 
 - [La&nbsp;bonne&nbsp;rédaction&nbsp;des&nbsp;labels](../wwdc/2019#la-bonne-redaction-des-labels)
 </div>
@@ -381,6 +425,26 @@ Il faut absolument formater les données en entrée pour obtenir une vocalisatio
                                                                            unitsStyle: .spellOut)
 </code></pre>
 
+<pre><code class="swiftui">
+let dateFormatter: DateFormatter = {
+    let formatter = Dateformatter()
+    formatter.dateFormat = "dd/MM/yyyy HH:mm"
+}()
+
+let longDateFormatter: DateFormatter = {
+    let formatter = Dateformatter()
+    formatter.dateStyle = .long
+    formatter.timeStyle = .medium
+    return formatter
+}() 
+
+var body: some View {
+        Text(dateFormatter.string(from: Date()))
+            .accessibiltyLabel(Text("Date"))
+            .accessibilityValue(Text(longDateFormatter.string(from: Date())))
+}
+</code></pre>
+
 </div>
 
 </div>
@@ -417,6 +481,13 @@ Comme pour les date et heure, il faut formater la donnée en entrée pour qu'ell
                                                                      number: .spellOut)
 </code></pre>
 
+<pre><code class="swiftui">
+let numberValue = NSNumber(value: 54038921.7)
+        
+Text(NumberFormatter.localizedString(from: numberValue, number: .decimal))
+    .accessibilityLabel(NumberFormatter.localizedString(from: numberValue,
+                                                        number: .spellOut))
+</code></pre>
 </div>
 
 </div>
@@ -503,6 +574,9 @@ L'idée est de séparer chaque paire de chiffres par une virgule qui va fournir 
         phoneNumberLabel.accessibilityLabel = spelledOutString
 </code></pre>
 
+<pre><code class="swiftui">
+</code></pre>
+
 </div>
 
 </div>
@@ -554,6 +628,11 @@ UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
 </code></pre>
 
 <pre><code class="swift">
+UIAccessibility.post(notification: .announcement,
+                     argument: "Message pour la vocalisation.")
+</code></pre>
+
+<pre><code class="swiftui">
 UIAccessibility.post(notification: .announcement,
                      argument: "Message pour la vocalisation.")
 </code></pre>
@@ -645,19 +724,23 @@ Le son utilisé pour notifier la modification est similaire à l'arrivée d'une 
 
 <pre><code class="swift">
 //L'élément 'myLabel' est sélectionné et vocalisé avec sa nouvelle valeur.
+
 @IBAction func tapHere(_ sender: UIButton) {
-        
     myLabel.accessibilityLabel = "Ceci est un nouveau label."
     UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged,
                          argument: myLabel)
 }
     
-//Le premier élément accessible de la page est sélectioné et vocalisé avec un son spécifique.
+//Le premier élément accessible de la page est sélectionné et vocalisé avec un son spécifique.
+
 @IBAction func clic(_ sender: UIButton) {
-        
     UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
                          argument: nil)
 }
+</code></pre>
+
+<pre><code class="swiftui">
+
 </code></pre>
 
 </div>
@@ -729,6 +812,10 @@ Si on utilise l'attribut `accessibilityLanguage` sur un `UILabel`, alors celui-c
     myLabel.accessibilityLanguage = "en"
     myLabel.accessibilityLabel = "This is a new label. Thank you."
 }
+</code></pre>
+
+<pre><code class="swiftui">
+
 </code></pre>
 
 </div>
@@ -886,6 +973,19 @@ override func viewDidAppear(_ animated: Bool) {
     }
 </code></pre>
 
+<pre><code class="swiftui">
+//Masquage d'une image décorative, en conservant les autres traits accessibles
+//comme un bouton, un lien, un label, etc. qui seront vocalisés par VoiceOver
+   
+    Image(decorative: "monImage")
+
+// Masquage de tous les traits associés à l'image (plus rien ne sera vocalisé par Voice Over)
+     
+     Image(decorative: "monImage")
+        .accessibilityHidden(true)
+
+</code></pre>
+
 </div>
 
 </div>
@@ -893,9 +993,11 @@ override func viewDidAppear(_ animated: Bool) {
 
 - [`isAccessibilityElement`](https://developer.apple.com/documentation/objectivec/nsobject/1615141-isaccessibilityelement)
 
-- [`accessibilityElementsHidden`](https://developer.apple.com/documentation/objectivec/nsobject/1615080-accessibilityelementshidden)
+- [`accessibilityElement`](https://developer.apple.com/documentation/swiftui/view/accessibilityelement(children:))
 
-- [`accessibilityViewIsModal`](https://developer.apple.com/documentation/objectivec/nsobject/1615089-accessibilityviewismodal)
+- [`accessibilityHidden`](https://developer.apple.com/documentation/swiftui/view/accessibilityhidden(_:)/)
+
+- [`isModal`](https://developer.apple.com/documentation/swiftui/accessibilitytraits/ismodal)
 </div>
 </div>
 <br><br>
@@ -995,6 +1097,17 @@ Création de l'élément accessible qui va regrouper les éléments souhaités a
 }
 </code></pre>
 
+<pre><code class="swiftui">
+    @State private var isChecked = false // valeur du switch par défaut
+    
+    HStack(){
+        Text("Texte descriptif")
+        Toggle("Test", isOn: $isChecked)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityHint("Texte descriptif groupé avec le bouton")
+</code></pre>
+
 </div>
 
 <br>... et implémentation de la classe utilisée pour définir de façon précise l'<a href="../wwdc/2017/215/#action-par-defaut-3738">action à associer au double tap d'activation</a> :
@@ -1073,7 +1186,8 @@ int indexSwitch = 1;
         let switchValue = (aSwitch.isOn) ? "activé" : "désactivé"
         
         self.isAccessibilityElement = true
-        self.accessibilityLabel = "le contrôle est " + switchValue.description
+        self.accessibilityLabel = "le contrôl
+        e est " + switchValue.description
         self.accessibilityHint = "tapez deux fois pour changer sa valeur."
     }
     
@@ -1205,6 +1319,9 @@ Cela permet notamment de faire des vocalisations uniques ou de définir un ordre
 - [`accessibilityActivate`](https://developer.apple.com/documentation/objectivec/nsobject/1615165-accessibilityactivate)
 
 - [`shouldGroupAccessibilityChildren`](https://developer.apple.com/documentation/objectivec/nsobject/1615143-shouldgroupaccessibilitychildren)
+
+- [`accessibilityElement`](https://developer.apple.com/documentation/swiftui/view/accessibilityelement(children:))
+
 </div>
 </div>
 <br><br>
@@ -1593,12 +1710,63 @@ extension UIView {
 }
 </code></pre>
 
+<pre><code class="swiftui">
+//La propriété wrapper AccessibilityFocusState permet de savoir si l'élément a le focus ou non
+
+struct MyView: View {
+    @AccessibilityFocusState private var isElementFocused: Bool
+    @State private var monTexte = ""
+
+    var body: some View {
+            Form {
+                TextField("Champ d'édition", text: $monTexte)
+                    .accessibilityFocused($isElementFocused)
+            }
+            .onChange(of: isElementFocused) { value in
+                print(value)
+            }
+    }
+}
+
+// Il est aussi possible de déplacer le focus automatiquement, par exemple ici lorsqu'une notification change
+//(exemple à retrouver ici https://developer.apple.com/documentation/swiftui/accessibilityfocusstate)
+
+struct CustomNotification: Equatable {
+    var text: String
+    var isPriority: Bool
+}
+
+struct ContentView: View {
+    @Binding var notification: CustomNotification?
+    @AccessibilityFocusState var isNotificationFocused: Bool
+
+    var body: some View {
+        VStack {
+            if let notification = self.notification {
+                Text(notification.text)
+                    .accessibilityFocused($isNotificationFocused)
+            }
+            Text("The main content for this view.")
+        }
+        .onChange(of: notification) { notification in
+            if (notification?.isPriority == true)  {
+                isNotificationFocused = true
+            }
+        }
+    }
+}
+
+</code></pre>
+
 </div>
 
 </div>
 <div class="tab-pane" id="focusElt-Links" role="tabpanel">
 
 - [`UIAccessibilityFocus`](https://developer.apple.com/documentation/uikit/accessibility/uiaccessibilityfocus)
+
+- [`accessibilityFocused`](https://developer.apple.com/documentation/swiftui/view/accessibilityfocused(_:)/)
+
 </div>
 </div>
 <br><br>
@@ -2457,7 +2625,7 @@ Lorsque la **gestuelle 'appui long' est déjà implémentée sur l'élément imp
            data-bs-toggle="tab" 
            href="#adjustable-Links" 
            role="tab" 
-           aria-selected="false">Lien</a>
+           aria-selected="false">Liens</a>
     </li>
 </ul><div class="tab-content">
 <div class="tab-pane show active"
@@ -2579,6 +2747,41 @@ class StepperWrapper: UIStackView {
 }
 </code></pre>
 
+
+<pre><code class="swiftui">
+struct ContentView: View {
+    @State private var value = 5
+
+    VStack {
+        Text("Value: \(value)")
+
+        Button("-") {
+            guard value > 0 else { return }
+            value -= 1
+        }
+
+        Button("+") {
+            guard value < 10 else { return }
+            value += 1
+        }
+    }
+    .accessibilityElement()
+    .accessibilityLabel("Valeur")
+    .accessibilityValue(String(value))    
+    .accessibilityAdjustableAction { direction in
+        switch direction {
+        case .decrement:
+            guard value > 0 else { break }
+            value -= 1
+        case .increment:
+            guard value < 10 else { break }
+            value += 1
+        @unknown default:
+            break
+        }
+    }
+}
+</code></pre>
 </div>
 
 <br>
@@ -2662,6 +2865,8 @@ class ContinuousAdjustableValues: UIViewController, AdjustableForAccessibilityDe
 <div class="tab-pane" id="adjustable-Links" role="tabpanel">
 
 - [`UIAccessibilityTraitAdjustable`](https://developer.apple.com/documentation/uikit/uiaccessibilitytraitadjustable)
+
+- [`accessibilityAdjustableAction`](https://developer.apple.com/documentation/swiftui/modifiedcontent/accessibilityadjustableaction(_:)/)
 </div>
 </div>
 <br><br>
@@ -3049,7 +3254,7 @@ L'implémentation d'une telle fonctionnalité au sein d'une application est donc
            data-bs-toggle="tab" 
            href="#a11yOptions-Link" 
            role="tab" 
-           aria-selected="false">Lien</a>
+           aria-selected="false">Liens</a>
     </li>
 </ul><div class="tab-content">
 <div class="tab-pane show active"
@@ -3077,6 +3282,19 @@ Une présentation très visuelle de certaines fonctions, peut-être moins utiles
     let isSwitchControlRunning = (UIAccessibility.isSwitchControlRunning ? 1 : 0)
         
     print("VoiceOver vaut \(isVoiceOverRunning) et SwichControl vaut \(isSwitchControlRunning).")
+</code></pre>
+
+
+<pre><code class="swiftui">
+
+// Booléen pour savoir si une option d'accessibilité est activée
+@Environment(\.accessibilityEnabled) private var accessibilityEnabled
+
+// Booléen pour savoir si Voice Over est activé
+@Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+
+// Booléen pour savoir si le contrôle de sélection est activé
+@Environment(\.accessibilitySwitchControlEnabled) private var switchControlEnabled
 </code></pre>
 
 </div>
@@ -3154,6 +3372,13 @@ Tous les <a href="https://developer.apple.com/documentation/uikit/accessibility/
 <div class="tab-pane" id="a11yOptions-Link" role="tabpanel">
 
 - [Options&nbsp;d'accessibilité](../conception/#options-daccessibilite) (partie conception iOS de ce site)
+
+- [`accessibilityEnabled`](https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityenabled/)
+
+- [`accessibilityVoiceOverEnabled`](https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityvoiceoverenabled/)
+
+- [`accessibilitySwitchControlEnabled`](https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityswitchcontrolenabled)
+
 </div>
 </div>
 <br><br>


### PR DESCRIPTION
# Description

Today the web site does not contain code samples written in _SwiftUI_, this pull request brings more details about this framework.

# Topics to update or check if needed

- [ ] Truncation hyphen
- [ ] Graphical elements size
- [ ] Large Content Viewer
- [ ] Continuous adjustable values
- [ ] Custom actions
- [ ] Custom rotor
- [ ] Accessibility options
- [ ] Navigation bar
- [ ] Speech synthesis
- [ ] Switch Control
- [ ] Vocalized application name

# Updated topics (or checked without updates needed)

- [x] Element trait (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Text alternatives (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Date, time and numbers (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Trigger a vocalization (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Notify a content change (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Change the vocalization language (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Hide elements (b5c9f9e127c6ca267c80d8466108f30eada760a6)
- [x] Grouping elements (cedfdb939)
- [x] Reading order (f276a01b9)
- [x] Custom content provider (641e0f7f9)
- [x] Focus on element (99f2e545f)
- [x] Modify the focus area of VoiceOver (1b3b80974ba3470e1eb8dc0f30bba5391178963f)
- [x] Modal view _(nothing found yet in SwiftUI API nor comments to add)_
- [x] Text size (f34beff05)

# Fixed typos

- [x] Bad variable name (128f9bf7c246cbe6c002281ca9a209a2a21e3068)