### PR TITLE
Fix cookies consentment panel

### DIFF
--- a/src/assets/tarteaucitron-boosted.css
+++ b/src/assets/tarteaucitron-boosted.css
@@ -286,7 +286,9 @@ div#tarteaucitronServices {
 .tarteaucitronSelfLink, #tarteaucitronAlertSmall #tarteaucitronCookiesListContainer #tarteaucitronCookiesList .tarteaucitronHidden,
 #tarteaucitron #tarteaucitronServices .tarteaucitronHidden {
   background: rgba(51, 51, 51, 0.07);
-}a.tarteaucitronSelfLink {
+}
+
+a.tarteaucitronSelfLink {
    text-align: center!important;
    display: block;
    padding: 7px!important;
@@ -720,17 +722,22 @@ div#tarteaucitronInfo {
 }
 
 a.tarteaucitronSelfLink {
-  position: absolute;
   left: 0;
   right: 0;
-  padding-top: 13px!important;
   display: block;
   text-shadow: 0 0 14px white;
   text-transform: uppercase;
-}.tarteaucitronMainLine .tarteaucitronH2 {
+  background-color: #000;
+}
+
+#tarteaucitronSave {
+  background-color: #fff;
+}
+
+.tarteaucitronMainLine .tarteaucitronH2 {
    /*font-size: 1.2em!important;*/
    margin-top: 4px!important;
- }
+}
 
 span.tarteaucitronTitle.tarteaucitronH3 {
   margin-top: 12px!important;


### PR DESCRIPTION
Closes #600

Netlify is unable to set or remove any cookie because of the domain name.
The only way to test this PR is to test it on localhost.
Here is the result:

![image](https://github.com/user-attachments/assets/09d5f353-4035-400e-af5d-754b81481868)

Not perfect but it is a quick and esay fix to remove one contrast problem.
A better version will be done when we have time.


