### PR TITLE
Fix semantic in listbox article

### DIFF
--- a/src/fr/articles/listbox/index.njk
+++ b/src/fr/articles/listbox/index.njk
@@ -35,7 +35,7 @@ Nous allons étudier le cas des <i lang="en">listbox</i> ou zone de liste. Il s'
 <p>À noter que les balises <code>ul</code> et <code>li</code> pourraient être remplacées par de simples balises <code>div</code>, leur sémantique est surchargée par le rôle <abbr>ARIA</abbr>.</p>
 
 <h3>Interactions</h3>
-<p>Pour coller avec le design pattern ou modèle de conception <abbr>ARIA</abbr> de la <span lang="en">listbox</span> (<a href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/" hreflang="en" lang="en">WAI-ARIA Authoring Practices Guide - listbox</a>), il est indispensable de gérer quelques interactions à l’aide de code JavaScript. Le clavier doit permettre de naviguer dans la liste :</p>
+<p>Pour coller avec le design pattern ou modèle de conception <abbr>ARIA</abbr> de la <span lang="en">listbox</span> (<a href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/" hreflang="en" lang="en"><abbr>WAI</abbr>-<abbr>ARIA</abbr> Authoring Practices Guide - listbox</a>), il est indispensable de gérer quelques interactions à l’aide de code JavaScript. Le clavier doit permettre de naviguer dans la liste :</p>
 <ul>
   <li>Flèche haut pour sélectionner l’élément précédent</li>
   <li>Flèche bas pour sélectionner l’élément suivant</li>


### PR DESCRIPTION
After some research, it's totally ok to have `<abbr>` inside a `<a>`

Preview: https://deploy-preview-706--a11y-guidelines.netlify.app/fr/articles/listbox/