### PR TITLE
Revert "update push as described in TAC installation guide"

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -89,7 +89,7 @@
           'phase': '{{ site.tracking.phase }}'
         }];
         tarteaucitron.user.googletagmanagerId = "{{ site.tracking.googletagmanagerId }}";
-        (tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+        (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');
       {%- endif -%}
       docsearch({{ site.getDocSearchConfig(locale) | dump | safe }});
     </script>


### PR DESCRIPTION
Reverts Orange-OpenSource/a11y-guidelines#740