### PR TITLE
[Fix] Tab order on cookies panel

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -157,6 +157,7 @@ module.exports = {
       "hashtag": "#cookie-consent", /* Open the panel with this hashtag */
       "cookieName": "cookie-consent", /* Cookie name */
       "orientation": "bottom", /* Banner position (top - bottom) */
+      "bodyPosition": "top", /* top to bring it as first element in DOM for accessibility */
       "showAlertSmall": false, /* Show the small banner on bottom right */
       "cookieslist": true, /* Show the cookie list */
       "adblocker": false, /* Show a Warning if an adblocker is detected */


### PR DESCRIPTION
Closes #839 

**Important PR to fix tab order.**
I added a parameter to make the cookie panel the first element in DOM so it is now the first element in tab order:

<img width="1306" height="97" alt="image" src="https://github.com/user-attachments/assets/b0db2280-dca0-496c-ba7c-4bf118b18812" />

**Open preview in private mode to test this PR.**
