### PR TITLE
fix: correct Algolia DocSearch accessibility issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -398,6 +398,7 @@
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1730,6 +1731,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -5112,6 +5114,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5794,6 +5797,7 @@
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -6991,6 +6995,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -41,6 +41,7 @@ module.exports = {
           resetButtonAriaLabel: 'Clear the query',
           cancelButtonText: 'Cancel',
           cancelButtonAriaLabel: 'Cancel',
+          searchInputLabel: 'Search on entire website',
         },
         startScreen: {
           recentSearchesTitle: 'Recent',
@@ -83,6 +84,7 @@ module.exports = {
           resetButtonAriaLabel: 'Effacer la recherche',
           cancelButtonText: 'Annuler',
           cancelButtonAriaLabel: 'Annuler',
+          searchInputLabel: 'Rechercher sur le site',
         },
         startScreen: {
           recentSearchesTitle: 'Récent',
@@ -107,7 +109,7 @@ module.exports = {
           searchByText: 'Recherché par',
         },
         noResultsScreen: {
-          noResultsText: 'Aucun résulat pour',
+          noResultsText: 'Aucun résultat pour',
           suggestedQueryText: 'Essayez de rechercher',
           reportMissingResultsText: 'Vous pensez que cette recherche devrait renvoyer des résultats ?',
           reportMissingResultsLinkText: 'Faites le nous savoir.',
@@ -157,7 +159,6 @@ module.exports = {
       "hashtag": "#cookie-consent", /* Open the panel with this hashtag */
       "cookieName": "cookie-consent", /* Cookie name */
       "orientation": "bottom", /* Banner position (top - bottom) */
-      "bodyPosition": "top", /* top to bring it as first element in DOM for accessibility */
       "showAlertSmall": false, /* Show the small banner on bottom right */
       "cookieslist": true, /* Show the cookie list */
       "adblocker": false, /* Show a Warning if an adblocker is detected */

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -159,6 +159,7 @@ module.exports = {
       "hashtag": "#cookie-consent", /* Open the panel with this hashtag */
       "cookieName": "cookie-consent", /* Cookie name */
       "orientation": "bottom", /* Banner position (top - bottom) */
+      "bodyPosition": "top", /* top to bring it as first element in DOM for accessibility */
       "showAlertSmall": false, /* Show the small banner on bottom right */
       "cookieslist": true, /* Show the cookie list */
       "adblocker": false, /* Show a Warning if an adblocker is detected */

--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -515,14 +515,14 @@ function tabPanelFocus(tabTitleID, tabDescriptionID) {
 }
 
 window.addEventListener('keydown', function(e) {
-    // Si la touche est '/' ET qu'on n'est pas en train d'écrire dans un champ texte
+    // If pressed key '/' AND we're not in a textarea
     if (e.key === '/' && !["INPUT", "TEXTAREA"].includes(e.target.tagName)) {
-        // On arrête la propagation immédiatement
+        // We stop propagation immediately
         e.stopImmediatePropagation();
-        // On empêche le comportement par défaut (recherche navigateur) si désiré
+        // We prevent browsers default behavious 
         e.preventDefault(); 
     }
-}, { capture: true }); // <--- Le secret est ici : "capture: true"
+}, { capture: true }); // 
 
 window.addEventListener('DOMContentLoaded', function () {
     //initPriorityNav()

--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -215,6 +215,86 @@ function manageEventTabPan() {
   }, "1000");
 })();
 
+/* Algolia DocSearch accessibility fixes for NVDA */
+(function () {
+    const lang = Application.lang;
+
+    const i18n = {
+        fr: {
+            inputLabel: 'Rechercher sur le site',
+            noResults: 'Aucun résultat',
+            resultsCount: function (n) { return n + ' résultat' + (n > 1 ? 's' : ''); }
+        },
+        en: {
+            inputLabel: 'Search in entire website',
+            noResults: 'No results',
+            resultsCount: function (n) { return n + ' result' + (n !== 1 ? 's' : ''); }
+        }
+    };
+
+    const t = i18n[lang] || i18n.en;
+
+    // Create a hidden live region for NVDA announcements
+    const liveRegion = document.createElement('div');
+    liveRegion.setAttribute('role', 'status');
+    liveRegion.setAttribute('aria-live', 'polite');
+    liveRegion.setAttribute('aria-atomic', 'true');
+    liveRegion.className = 'visually-hidden';
+    document.body.appendChild(liveRegion);
+
+    function announce(message) {
+        liveRegion.textContent = '';
+        //Force reflow so NVDA picks up the change
+        setTimeout(function () { liveRegion.textContent = message; }, 50);
+    }
+
+    /*
+     * Outer observer – watches <body> for direct child changes.
+     * DocSearch appends its modal as a direct child of <body> when the user
+     * opens the search dialog, so childList: true (without subtree) is enough
+     * and avoids unnecessary overhead.
+     */
+    const bodyObserver = new MutationObserver(function () {
+        const modal = document.querySelector('.DocSearch-Modal');
+        if (!modal) return;
+
+        // Fix 1 – aria-label correction.
+        // DocSearch hardcodes aria-label="Search" on the <input> in English.
+        // We overwrite it with the locale-aware label only when it differs, to
+        // avoid triggering an unnecessary mutation loop.
+        const input = modal.querySelector('input.DocSearch-Input');
+        if (input && input.getAttribute('aria-label') !== t.inputLabel) {
+            input.setAttribute('aria-label', t.inputLabel);
+        }
+
+        /*
+         * Inner observer – watches the modal's entire subtree for DOM changes.
+         * Every keystroke causes DocSearch to re-render the result list, so we
+         * react to those mutations to determine what to announce:
+         *   - If .DocSearch-NoResults is present → announce "no results".
+         *   - If .DocSearch-Hit elements are present → announce the count.
+         * Both checks use querySelector/querySelectorAll at call time (not
+         * cached) to reflect the current state of the DOM after the mutation.
+         */
+        const resultsObserver = new MutationObserver(function () {
+            const noResults = modal.querySelector('.DocSearch-NoResults');
+            if (noResults) {
+                announce(t.noResults);
+                return;
+            }
+
+            const hits = modal.querySelectorAll('.DocSearch-Hit');
+            if (hits.length > 0) {
+                announce(t.resultsCount(hits.length));
+            }
+        });
+
+        resultsObserver.observe(modal, { childList: true, subtree: true });
+    });
+
+    bodyObserver.observe(document.body, { childList: true });
+})();
+
 /* Highlight searched term in result page */
 (function () {
   document.addEventListener("DOMContentLoaded", () => {
@@ -433,6 +513,16 @@ function tabPanelFocus(tabTitleID, tabDescriptionID) {
     elementTarget.focus();
     document.getElementById(tabDescriptionID).scrollIntoView({behavior: 'smooth', block: 'start'})
 }
+
+window.addEventListener('keydown', function(e) {
+    // Si la touche est '/' ET qu'on n'est pas en train d'écrire dans un champ texte
+    if (e.key === '/' && !["INPUT", "TEXTAREA"].includes(e.target.tagName)) {
+        // On arrête la propagation immédiatement
+        e.stopImmediatePropagation();
+        // On empêche le comportement par défaut (recherche navigateur) si désiré
+        e.preventDefault(); 
+    }
+}, { capture: true }); // <--- Le secret est ici : "capture: true"
 
 window.addEventListener('DOMContentLoaded', function () {
     //initPriorityNav()

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -251,6 +251,26 @@ pre code {
     font-weight: bolder;
 }
 
+/* Popup structural areas – not interactive (interactive children override with their own cursor) */
+.DocSearch-Modal,
+.DocSearch-Footer,
+.DocSearch-Dropdown,
+.DocSearch-SearchBar {
+    cursor: default;
+}
+
+/* Informational keyboard hints in footer – not interactive (Algolia logo link is excluded) */
+.DocSearch-Commands,
+.DocSearch-Commands li,
+.DocSearch-Commands .DocSearch-Commands-Key {
+    cursor: default;
+}
+
+/* Empty "no recent searches" state – not interactive */
+.DocSearch-StartScreen {
+    cursor: default;
+}
+
 .DocSearch-Button-Container {
     align-items: center;
     display: flex;


### PR DESCRIPTION
- Block unwanted '/' keyboard shortcut that was triggering the browser
  native search instead of being handled by the page
- Correct accessible name on DocSearch input (DocSearch hardcodes
  aria-label="Search" regardless of locale; overridden to locale-aware
  label)
- Announce result count to NVDA via polite ARIA live region (DocSearch
  does not natively announce how many results were found)
- Announce "no results" state to NVDA via polite ARIA live region
  (DocSearch shows a visual message only, screen readers were silent)
- Remove unwanted pointer cursor on non-interactive areas of the popup
  (modal, footer, dropdown, keyboard hint labels); interactive elements
  (input, buttons, Algolia logo link, result links) are unaffected