### PR TITLE
fix: correct algolia's user input vocalisation and focus behavious

### DIFF
--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -258,9 +258,26 @@ function manageEventTabPan() {
      * opens the search dialog, so childList: true (without subtree) is enough
      * and avoids unnecessary overhead.
      */
+    let modalWasOpen = false;
+
     const bodyObserver = new MutationObserver(function () {
         const modal = document.querySelector('.DocSearch-Modal');
+
+        // Fix 3 – Focus restoration on modal close.
+        // DocSearch does not return focus to the trigger button when the modal
+        // is closed, causing Tab to restart from the top of the page.
+        // We detect the modal disappearing and restore focus to .DocSearch-Button.
+        if (!modal && modalWasOpen) {
+            modalWasOpen = false;
+            const triggerButton = document.querySelector('.DocSearch-Button');
+            if (triggerButton) {
+                triggerButton.focus();
+            }
+            return;
+        }
+
         if (!modal) return;
+        modalWasOpen = true;
 
         // Fix 1 – aria-label correction.
         // DocSearch hardcodes aria-label="Search" on the <input> in English.
@@ -269,6 +286,84 @@ function manageEventTabPan() {
         const input = modal.querySelector('input.DocSearch-Input');
         if (input && input.getAttribute('aria-label') !== t.inputLabel) {
             input.setAttribute('aria-label', t.inputLabel);
+        }
+
+        // Fix 2 – aria-activedescendant management for NVDA.
+        //
+        // Problem: DocSearch sets aria-activedescendant to the first result as
+        // soon as results appear, which causes NVDA to read the result item
+        // instead of echoing the user's typed characters.
+        //
+        // Additionally, DocSearch internally tracks highlighted index (starts
+        // at 0). If we remove aria-activedescendant during typing but DocSearch
+        // keeps index=0, the first ArrowDown advances to item 1 and the first
+        // result is never announced.
+        //
+        // Solution:
+        //  - While typing: remove aria-activedescendant → NVDA echoes chars.
+        //  - First ArrowDown/Up after typing: intercept in capture phase,
+        //    block the event (DocSearch keeps index 0), and manually set
+        //    aria-activedescendant to the first highlighted item → NVDA
+        //    announces the first result.
+        //  - Subsequent arrows: DocSearch handles normally (index 0→1, 1→2…).
+        if (input && !input.dataset.a11yPatched) {
+            input.dataset.a11yPatched = 'true';
+
+            // Ensure the input is reachable via Tab
+            input.setAttribute('tabindex', '0');
+
+            let isNavigating = false;
+
+            // Capture-phase handler on the modal intercepts arrow keys BEFORE
+            // DocSearch's own handler can process them.
+            modal.addEventListener('keydown', function (e) {
+                if (e.target !== input) return;
+
+                if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                    if (!isNavigating) {
+                        // First arrow press after typing: block DocSearch from
+                        // advancing its internal counter.
+                        isNavigating = true;
+                        e.stopPropagation();
+                        e.preventDefault();
+
+                        // Manually announce the already-highlighted first item
+                        // by setting aria-activedescendant to its ID.
+                        const activeItem = modal.querySelector('[aria-selected="true"]');
+                        if (activeItem) {
+                            input.setAttribute('aria-activedescendant', activeItem.id);
+                        } else {
+                            // Fallback: pick the first hit link (has an ID like docsearch-item-X)
+                            const firstHitLink = modal.querySelector('.DocSearch-Hit a[id]');
+                            if (firstHitLink) {
+                                input.setAttribute('aria-activedescendant', firstHitLink.id);
+                            }
+                        }
+                        return;
+                    }
+                    // Subsequent arrows: let DocSearch handle normally
+                } else {
+                    isNavigating = false;
+                    input.removeAttribute('aria-activedescendant');
+                }
+            }, true); // ← capture phase
+
+            input.addEventListener('input', function () {
+                isNavigating = false;
+                input.removeAttribute('aria-activedescendant');
+            });
+
+            // Observe attribute changes to strip aria-activedescendant
+            // when DocSearch re-applies it after a re-render (during typing)
+            const inputAttrObserver = new MutationObserver(function (mutations) {
+                if (isNavigating) return;
+                mutations.forEach(function (m) {
+                    if (m.attributeName === 'aria-activedescendant' && !isNavigating) {
+                        input.removeAttribute('aria-activedescendant');
+                    }
+                });
+            });
+            inputAttrObserver.observe(input, { attributes: true, attributeFilter: ['aria-activedescendant'] });
         }
 
         /*


### PR DESCRIPTION
This MR fixes three accessibility issues with the Algolia DocSearch modal when used with NVDA screen reader.

Problems
User input not vocalized — DocSearch sets aria-activedescendant on the search input as soon as results appear, causing NVDA to announce the first result instead of echoing the characters the user is typing.

First result skipped during arrow navigation — After typing, DocSearch internally highlights index 0 (first result). When the user presses ArrowDown for the first time, DocSearch advances to index 1, so the first result is never announced by NVDA.

Focus lost on modal close — When the DocSearch modal is dismissed (Escape, click outside, or result selection), focus is not returned to the trigger button. This causes keyboard navigation (Tab) to restart from the top of the page instead of continuing from where the user left off.