### PR TITLE
add tabindex to fix skip-link with new Firefox version

### DIFF
--- a/src/_includes/components/header/main-navigation.njk
+++ b/src/_includes/components/header/main-navigation.njk
@@ -1,7 +1,7 @@
 {% import "../ui.njk" as ui with context %}
 
 <div class="navbar navbar-expand-md" data-bs-theme="dark">
-  <nav id="main-menu" class="container-lg justify-content-md-start align-items-center" role="navigation" aria-label="{{ 'navigation.main.label' | translate }}">
+  <nav id="main-menu" class="container-lg justify-content-md-start align-items-center" role="navigation" aria-label="{{ 'navigation.main.label' | translate }}" tabindex=-1>
     <a href="/{{ locale }}/" class="navbar-brand flex-grow-1 flex-md-grow-0" title="{{ 'header.logoAlt' | translate }}">
       <img src="/assets/images/orange-logo.svg" alt="{{ 'header.logoAlt' | translate }}" width="50" height="50">
     </a>
@@ -22,7 +22,7 @@
       </ul>
     </div>
 
-    <div id="search-input"></div>
+    <div id="search-input" tabindex=-1></div>
 
   </nav>
 </div>

--- a/src/_includes/components/header/main-navigation.njk
+++ b/src/_includes/components/header/main-navigation.njk
@@ -1,7 +1,7 @@
 {% import "../ui.njk" as ui with context %}
 
 <div class="navbar navbar-expand-md" data-bs-theme="dark">
-  <nav id="main-menu" class="container-lg justify-content-md-start align-items-center" role="navigation" aria-label="{{ 'navigation.main.label' | translate }}" tabindex=-1>
+  <nav id="main-menu" class="container-lg justify-content-md-start align-items-center" role="navigation" aria-label="{{ 'navigation.main.label' | translate }}" tabindex="-1">
     <a href="/{{ locale }}/" class="navbar-brand flex-grow-1 flex-md-grow-0" title="{{ 'header.logoAlt' | translate }}">
       <img src="/assets/images/orange-logo.svg" alt="{{ 'header.logoAlt' | translate }}" width="50" height="50">
     </a>
@@ -22,7 +22,7 @@
       </ul>
     </div>
 
-    <div id="search-input" tabindex=-1></div>
+    <div id="search-input" tabindex="-1"></div>
 
   </nav>
 </div>

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,6 +1,6 @@
 {% import "../components/ui.njk" as ui with context %}
 
-<footer id="footer" class="o-footer{% if page.url | isHomeUrl %} mt-0{% endif %}" role="contentinfo">
+<footer id="footer" class="o-footer{% if page.url | isHomeUrl %} mt-0{% endif %}" role="contentinfo" tabindex=-1>
   <div class="container-lg">
     <nav class="py-2" role="navigation">
       <ul class="nav align-items-center flex-column flex-sm-row">

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,6 +1,6 @@
 {% import "../components/ui.njk" as ui with context %}
 
-<footer id="footer" class="o-footer{% if page.url | isHomeUrl %} mt-0{% endif %}" role="contentinfo" tabindex=-1>
+<footer id="footer" class="o-footer{% if page.url | isHomeUrl %} mt-0{% endif %}" role="contentinfo" tabindex="-1">
   <div class="container-lg">
     <nav class="py-2" role="navigation">
       <ul class="nav align-items-center flex-column flex-sm-row">

--- a/src/_includes/templates/default.njk
+++ b/src/_includes/templates/default.njk
@@ -22,7 +22,7 @@
             </div>
           </div>
         {% endif %}
-        <main id="main-content" class="col-md-{{ mainContentColumn }}" role="main">
+        <main id="main-content" class="col-md-{{ mainContentColumn }}" role="main" tabindex=-1>
           {% if titleBeforeTag %}
             <h1>{{ title }}</h1>
             {% if tags %}
@@ -69,7 +69,7 @@
       </div>
     </div>
   {%- else -%}
-    <main id="main-content" class="container-lg pt-4" role="main">
+    <main id="main-content" class="container-lg pt-4" role="main" tabindex=-1>
       {{ content | safe }}
     </main>
   {%- endif -%}

--- a/src/_includes/templates/default.njk
+++ b/src/_includes/templates/default.njk
@@ -22,7 +22,7 @@
             </div>
           </div>
         {% endif %}
-        <main id="main-content" class="col-md-{{ mainContentColumn }}" role="main" tabindex=-1>
+        <main id="main-content" class="col-md-{{ mainContentColumn }}" role="main" tabindex="-1">
           {% if titleBeforeTag %}
             <h1>{{ title }}</h1>
             {% if tags %}
@@ -69,7 +69,7 @@
       </div>
     </div>
   {%- else -%}
-    <main id="main-content" class="container-lg pt-4" role="main" tabindex=-1>
+    <main id="main-content" class="container-lg pt-4" role="main" tabindex="-1">
       {{ content | safe }}
     </main>
   {%- endif -%}

--- a/src/_includes/templates/home.njk
+++ b/src/_includes/templates/home.njk
@@ -2,7 +2,7 @@
 {% import "../components/ui.njk" as ui with context %}
 
 {% block content %}
-<main id="main-content" class="pt-4" role="main" tabindex=-1>
+<main id="main-content" class="pt-4" role="main" tabindex="-1">
   <section class="container-lg">
     <div class="row">
       <div class="col-md-7 pb-5">{{ content | safe }}</div>

--- a/src/_includes/templates/home.njk
+++ b/src/_includes/templates/home.njk
@@ -2,7 +2,7 @@
 {% import "../components/ui.njk" as ui with context %}
 
 {% block content %}
-<main id="main-content" class="pt-4" role="main">
+<main id="main-content" class="pt-4" role="main" tabindex=-1>
   <section class="container-lg">
     <div class="row">
       <div class="col-md-7 pb-5">{{ content | safe }}</div>


### PR DESCRIPTION
With last versions of Firefox (at least from v152), skip links must target an element which is focusable.
This PR adds tabindex="-1" on not focusable targeted elements 