### PR TITLE
fix: update cookie policy link

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -82,7 +82,9 @@
     {%- endfor -%}
     <script>
       var tarteaucitronForceLanguage = "{{ locale }}"
-      tarteaucitron.init({{ site.tracking.tarteaucitronConfig | dump | safe }});
+      var tarteaucitronConfig = {{ site.tracking.tarteaucitronConfig | dump | safe }};
+      tarteaucitronConfig.readmoreLink = Application.lang === "fr" ? "/fr/a-propos/#gestion-des-cookies" : "/en/about/#cookie-management";
+      tarteaucitron.init(tarteaucitronConfig);
       {%- if config.environment == "production" -%}
         var dataLayer = [{
           'site_name': '{{ site.tracking.siteName }}',


### PR DESCRIPTION
## Summary
- Update the cookie banner read-more link away from the broken /cookiespolicy path.
- Use the French cookie-management anchor for French pages and the English cookie-management anchor for English pages.

## Source proof
- Issue #807 reports that https://a11y-guidelines.orange.com/cookiespolicy returns 404 and proposes the localized about-page anchors.
- Current HTTP checks returned 404 for /cookiespolicy and 200 for /en/about/#cookie-management and /fr/a-propos/#gestion-des-cookies.

## Verification
- git diff --check
- Template proof script confirmed both localized targets are present.
- npm run build:prod was attempted after npm ci; Eleventy generated the relevant pages and showed the localized override in _site, but the full build stopped on EMFILE too many open files while passthrough-copying image assets in this environment.

## Cleanup
- Removed node_modules, _site, and local cache/build artifacts created during verification.