### PR TITLE
[Fix] Collapsed margin under table

### DIFF
--- a/src/en/articles/autocomplete-attribute.md
+++ b/src/en/articles/autocomplete-attribute.md
@@ -8,6 +8,13 @@ tags:
   - advanced
 ---
 
+<style>
+  table + p {
+    margin-top: 1rem;
+  }
+</style>
+
+
 Forms are at the heart of the user experience on the web: registration, login, payment… They are everywhere.
 However, filling them out can be an obstacle, especially for people with disabilities. The accessibility of forms is therefore a key challenge.
 

--- a/src/en/articles/autocomplete-attribute.md
+++ b/src/en/articles/autocomplete-attribute.md
@@ -14,7 +14,6 @@ tags:
   }
 </style>
 
-
 Forms are at the heart of the user experience on the web: registration, login, payment… They are everywhere.
 However, filling them out can be an obstacle, especially for people with disabilities. The accessibility of forms is therefore a key challenge.
 

--- a/src/fr/articles/autocomplete-attribute.md
+++ b/src/fr/articles/autocomplete-attribute.md
@@ -8,6 +8,12 @@ tags:
   - advanced
 ---
 
+<style>
+  table + p {
+    margin-top: 1rem;
+  }
+</style>
+
 Les formulaires sont au cœur de l'expérience utilisateur sur le web : inscription, connexion, paiement… Ils sont partout.
 Pourtant, leur remplissage peut représenter un obstacle, en particulier pour les personnes en situation de handicap. L'accessibilité des formulaires est donc un enjeu majeur.
 Parmi les mécanismes souvent négligés, l'attribut HTML `autocomplete` joue un rôle clé.


### PR DESCRIPTION
Add basic CSS rule to improve design when a `p` is following a `table`.

Before:
<img width="247" height="58" alt="image" src="https://github.com/user-attachments/assets/947a3a80-80b9-410d-a384-6945f588d71b" />

After: 
<img width="247" height="66" alt="image" src="https://github.com/user-attachments/assets/33374e84-4fd8-49a3-9ad6-fae9aea179ba" />
