### PR TITLE
fix(a11y): add accessible name to footer nav

### DIFF
--- a/src/_data/locales.js
+++ b/src/_data/locales.js
@@ -20,6 +20,9 @@ module.exports = {
       },
       side: {
         label: 'Topics'
+      },
+      footer: {
+        label: 'Footer navigation'
       }
     },
     header: {
@@ -103,6 +106,9 @@ module.exports = {
       },
       side: {
         label: 'Thématiques'
+      },
+      footer: {
+        label: 'Navigation du pied de page'
       }
     },
     header: {

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -2,7 +2,7 @@
 
 <footer id="footer" class="o-footer{% if page.url | isHomeUrl %} mt-0{% endif %}" role="contentinfo" tabindex="-1">
   <div class="container-lg">
-    <nav class="py-2" role="navigation">
+<nav class="py-2" role="navigation" aria-label="{{ 'navigation.footer.label' | translate }}">
       <ul class="nav align-items-center flex-column flex-sm-row">
         {%- for link in navigation.footer[locale] -%}
           <li class="nav-item">


### PR DESCRIPTION
## Summary
The footer `<nav>` element did not expose an accessible name while multiple navigation landmarks were present on the page, making it impossible for assistive technology users to distinguish between them.

## Changes
- Added `aria-label="{{ 'navigation.footer.label' | translate }}"` to the footer `<nav>` element
- Added the corresponding translation keys in the translation files

Relates to #899