### PR TITLE
fix(a11y): add aria-hidden to SVG elements

### DIFF
--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -208,11 +208,35 @@ function manageEventTabPan() {
 
 /* Filter docsearch */
 (function () {
-  setTimeout(() => {
-    let svgLoupe = document.getElementsByClassName("DocSearch-Search-Icon")[0];
-    svgLoupe.setAttribute("aria-hidden", true);
-    svgLoupe.setAttribute("focusable", false);
-  }, "1000");
+    const observer = new MutationObserver(function (mutations, obs) {
+        const svgLoupe = document.querySelector('.DocSearch-Search-Icon')
+        const svgCtrl = document.querySelector('.DocSearch-Control-Key-Icon')
+
+        if (svgLoupe && svgCtrl) {
+            // Hide the search icon from assistive technologies
+            svgLoupe.setAttribute('aria-hidden', 'true')
+            svgLoupe.setAttribute('focusable', 'false')
+
+            // Hide the decorative Ctrl SVG from assistive technologies
+            svgCtrl.setAttribute('aria-hidden', 'true')
+            svgCtrl.setAttribute('focusable', 'false')
+
+            // Stop observing once both elements are found and updated
+            obs.disconnect()
+            clearTimeout(safetyTimeout)
+        }
+    })
+
+    // Stop observing after 10 seconds as a safety measure
+    const safetyTimeout = setTimeout(function () {
+        observer.disconnect()
+    }, 10000)
+
+    // Start observing the DOM for changes
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
+    })
 })();
 
 /**


### PR DESCRIPTION
## Summary
The SVG icon representing the "Ctrl" key in the DocSearch button was visible to assistive 
technologies without an accessible name, triggering an accessibility violation.

## Changes
- Added `aria-hidden="true"` and `focusable="false"` to `.DocSearch-Control-Key-Icon`
- Added `aria-hidden="true"` and `focusable="false"` to `.DocSearch-Search-Icon`

## Notes
The shortcut `Ctrl+K` is already announced via the `aria-label` of the parent button. 
Both SVGs are purely decorative in this context.

### Why a MutationObserver instead of a setTimeout?
The DocSearch button is injected asynchronously into the DOM. A `setTimeout` approach 
would rely on an arbitrary delay to wait for the button to be available, which is both 
unreliable and dependent on the user's device performance. A `MutationObserver` watches 
for actual DOM changes and applies the fix as soon as the button is effectively rendered, 
making the solution deterministic and robust regardless of loading conditions.

Relates to #899 
