### PR TITLE
fix(a11y): fix language selector visibility at 200% zoom

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -1,8 +1,8 @@
 {% import "../components/ui.njk" as ui with context %}
 
 <header role="banner">
-  <nav class="navbar navbar-expand-lg supra" aria-label="{{ 'skiplinks.label' | translate }} - {{ 'changelang.label' | translate }}" data-bs-theme="dark">
-   <div class="container-lg">
+  <nav class="navbar navbar-expand-md supra" aria-label="{{ 'skiplinks.label' | translate }} - {{ 'changelang.label' | translate }}" data-bs-theme="dark">
+   <div class="container-md">
       {% include "components/header/skip-links.njk" %}
       {{ ui.changelang("supra") }}
     </div>


### PR DESCRIPTION
## Summary
The language selector was disappearing at 200% zoom and only reappearing in the burger menu at 250% zoom, violating WCAG 1.4.4 (Resize text, Level AA).

## Changes
- Replaced `.navbar-expand-lg` with `.navbar-expand-md` on the supra navbar
- Replaced `.container-lg` with `.container-md` on the supra navbar container

Relates to #899 
