### PR TITLE
fix(a11y): fix missing status in TarteAuCitron modal

### DIFF
--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -45,6 +45,9 @@
         servicesContainer
           .querySelectorAll(".tarteaucitronStatusInfo")
           .forEach(function (statusEl) {
+            // Add role="status" so screen readers announce the content
+            statusEl.setAttribute("role", "status");
+
             // Get the service name from the sibling span
             const serviceName = statusEl
               .closest(".tarteaucitronName")

--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -26,17 +26,50 @@
         })
     }, {once: true})
 
-    window.addEventListener('tac.open_panel', function () {
-        const servicesContainer = document.getElementById('tarteaucitronServices_api')
+    window.addEventListener(
+      "tac.open_panel",
+      function () {
+        const servicesContainer = document.getElementById(
+          "tarteaucitronServices_api",
+        );
 
-        servicesContainer.querySelectorAll('button').forEach(function (button) {
-            if (button.classList.contains('tarteaucitronAllow')) {
-                button.classList.add('btn', 'btn-primary', 'btn-inverse', 'ms-2')
-            } else {
-                button.classList.add('btn', 'btn-info', 'ms-2')
+        servicesContainer.querySelectorAll("button").forEach(function (button) {
+          if (button.classList.contains("tarteaucitronAllow")) {
+            button.classList.add("btn", "btn-primary", "btn-inverse", "ms-2");
+          } else {
+            button.classList.add("btn", "btn-info", "ms-2");
+          }
+        });
+
+        // Build a complete aria-label on .tarteaucitronStatusInfo
+        servicesContainer
+          .querySelectorAll(".tarteaucitronStatusInfo")
+          .forEach(function (statusEl) {
+            // Get the service name from the sibling span
+            const serviceName = statusEl
+              .closest(".tarteaucitronName")
+              .querySelector(".tarteaucitronH3")
+              ?.textContent.trim();
+
+            // Get the current status
+            const currentStatus = statusEl
+              .querySelector(".tacCurrentStatus")
+              ?.textContent.trim();
+
+            // Get the cookie information
+            const cookieInfo = statusEl
+              .querySelector(".tarteaucitronListCookies")
+              ?.textContent.trim();
+
+            // Build and apply the complete aria-label
+            if (serviceName && currentStatus) {
+              const label = `${serviceName} ${currentStatus}${cookieInfo ? " - " + cookieInfo : ""}`;
+              statusEl.setAttribute("aria-label", label);
             }
-        })
-    }, {once: true})
+          });
+      },
+      { once: true },
+    );
 })();
 
 /* Tab language IOS */


### PR DESCRIPTION
## Summary
Status messages in the TarteAuCitron cookies modal were not exposed to assistive 
technologies, meaning screen reader users were not informed of cookie consent changes.

## Changes
- Added `role="status"` dynamically on `.tarteaucitronStatusInfo` elements
- Built a dynamic `aria-label` on `.tarteaucitronStatusInfo` combining the service 
  name and its current status, triggered on the `tac.open_panel` event

## Why an aria-label instead of role="status" on the parent container?
The parent `.tarteaucitronName` contains unwanted elements for a `role="status"` 
announcement:
- ✅ `span.tarteaucitronH3` → service name
- ✅ `div.tarteaucitronStatusInfo` → current status and cookie info
- ❌ `a.tarteaucitronReadmoreInfo` → "En savoir plus"
- ❌ `a.tarteaucitronReadmoreOfficial` → "Voir le site officiel"

Placing `role="status"` directly on `.tarteaucitronStatusInfo` and building a precise 
`aria-label` ensures that screen readers announce exactly:
"Google Tag Manager interdit - Ce service n'a déposé aucun cookie."
without including the unwanted links.

## Notes
- Both `role="status"` and `aria-label` are applied dynamically via JavaScript 
  on the first opening of the panel (`{ once: true }`), consistent with the existing 
  event listener pattern in the codebase.
- This fix ensures that status messages are announced by screen readers without 
  requiring focus to move to the element.

Relates to #899