### PR TITLE
fix(a11y): simplify dynamic aria-label on tarteaucitronStatusInfo

### DIFF
--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -52,57 +52,51 @@
         // Apply dark theme to the main line offset
         mainLineOffset.setAttribute('data-bs-theme', 'dark');
 
-        // Apply Bootstrap classes to buttons
+        // Apply Boosted classes to buttons
         servicesContainer.querySelectorAll('button').forEach(function (button) {
             applyButtonClasses(button);
         });
 
         // Build a complete aria-label on .tarteaucitronStatusInfo
         servicesContainer
-            .querySelectorAll('.tarteaucitronStatusInfo')
-            .forEach(function (statusEl) {
-                // Add role="status" so screen readers announce the content
-                statusEl.setAttribute('role', 'status');
+          .querySelectorAll(".tarteaucitronStatusInfo")
+          .forEach(function (statusEl) {
+            // Add role="status" so screen readers announce the content
+            statusEl.setAttribute("role", "status");
 
-                // Helper function to build and apply the aria-label
-                function updateAriaLabel() {
-                    const serviceName = statusEl
-                        .closest('.tarteaucitronName')
-                        .querySelector('.tarteaucitronH3')
-                        ?.textContent.trim();
+            // Helper function to build and apply the aria-label
+            function updateAriaLabel() {
+              const serviceName = statusEl
+                .closest(".tarteaucitronName")
+                .querySelector(".tarteaucitronH3")
+                ?.textContent.trim();
 
-                    const currentStatus = statusEl
-                        .querySelector('.tacCurrentStatus')
-                        ?.textContent.trim();
+              const currentStatus = statusEl
+                .querySelector(".tacCurrentStatus")
+                ?.textContent.trim();
 
-                    const cookieInfo = statusEl
-                        .querySelector('.tarteaucitronListCookies')
-                        ?.textContent.trim();
+              if (serviceName && currentStatus) {
+                const label = `${serviceName} ${currentStatus}`;
+                statusEl.setAttribute("aria-label", label);
+              }
+            }
 
-                    if (serviceName && currentStatus) {
-                        const label = `${serviceName} ${currentStatus}${cookieInfo ? ' - ' + cookieInfo : ''}`;
-                        statusEl.setAttribute('aria-label', label);
-                    }
-                }
+            // Build the aria-label on first open
+            updateAriaLabel();
 
-                // Build the aria-label on first open
-                updateAriaLabel();
-
-                // Watch for status changes and rebuild the aria-label accordingly
-                const observer = new MutationObserver(updateAriaLabel);
-                observer.observe(statusEl.querySelector('.tacCurrentStatus'), {
-                    childList: true,
-                    characterData: true,
-                    subtree: true,
-                });
+            // Watch for status changes and rebuild the aria-label accordingly
+            const observer = new MutationObserver(updateAriaLabel);
+            observer.observe(statusEl.querySelector(".tacCurrentStatus"), {
+              childList: true,
+              characterData: true,
+              subtree: true,
             });
+          });
     }, { once: true });
 
 })();
 
-
 /* Tab language IOS */
-
 function automaticTabPan() {
     var AllLanguage = {
         "objectivec": {


### PR DESCRIPTION
## Summary
The `aria-label` built on `.tarteaucitronStatusInfo` elements included the content 
of `.tarteaucitronListCookies`, which loads asynchronously and caused the label 
to be incomplete or empty on first render.

## Changes
- Removed `.tarteaucitronListCookies` from the `aria-label` computation
- The `aria-label` now only concatenates `.tarteaucitronH3` and `.tacCurrentStatus`

## Why
`.tarteaucitronListCookies` content is not immediately available when the panel 
opens, leading to inconsistent `aria-label` values. Since the plugin behavior 
cannot be altered, the simplest and most reliable solution is to exclude this 
part from the label.
