### PR TITLE
fix(a11y): hide decorative keyboard shortcut keys from assistive technologies

### DIFF
--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -264,35 +264,39 @@ function manageEventTabPan() {
 
 /* Filter docsearch */
 (function () {
-    const observer = new MutationObserver(function (mutations, obs) {
-        const svgLoupe = document.querySelector('.DocSearch-Search-Icon')
-        const svgCtrl = document.querySelector('.DocSearch-Control-Key-Icon')
+  const observer = new MutationObserver(function (mutations, obs) {
+    const svgLoupe = document.querySelector(".DocSearch-Search-Icon");
+    const svgCtrl = document.querySelector(".DocSearch-Control-Key-Icon");
+    const buttonKeys = document.querySelector(".DocSearch-Button-Keys");
 
-        if (svgLoupe && svgCtrl) {
-            // Hide the search icon from assistive technologies
-            svgLoupe.setAttribute('aria-hidden', 'true')
-            svgLoupe.setAttribute('focusable', 'false')
+    if (svgLoupe && svgCtrl && buttonKeys) {
+      // Hide the search icon from assistive technologies
+      svgLoupe.setAttribute("aria-hidden", "true");
+      svgLoupe.setAttribute("focusable", "false");
 
-            // Hide the decorative Ctrl SVG from assistive technologies
-            svgCtrl.setAttribute('aria-hidden', 'true')
-            svgCtrl.setAttribute('focusable', 'false')
+      // Hide the decorative Ctrl SVG from assistive technologies
+      svgCtrl.setAttribute("aria-hidden", "true");
+      svgCtrl.setAttribute("focusable", "false");
 
-            // Stop observing once both elements are found and updated
-            obs.disconnect()
-            clearTimeout(safetyTimeout)
-        }
-    })
+      // Hide the decorative keyboard shortcut keys from assistive technologies
+      buttonKeys.setAttribute("aria-hidden", "true");
 
-    // Stop observing after 10 seconds as a safety measure
-    const safetyTimeout = setTimeout(function () {
-        observer.disconnect()
-    }, 10000)
+      // Stop observing once all elements are found and updated
+      obs.disconnect();
+      clearTimeout(safetyTimeout);
+    }
+  });
 
-    // Start observing the DOM for changes
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true
-    })
+  // Stop observing after 10 seconds as a safety measure
+  const safetyTimeout = setTimeout(function () {
+    observer.disconnect();
+  }, 10000);
+
+  // Start observing the DOM for changes
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
 })();
 
 /**


### PR DESCRIPTION
## Summary
The `.DocSearch-Button-Keys` span, which displays the keyboard shortcut (Ctrl+K), 
was visible to assistive technologies despite being purely decorative. The button 
already carries an explicit `aria-label` that includes the shortcut information, 
making the visual keys redundant for screen reader users.

## Changes
- Added `aria-hidden="true"` on `.DocSearch-Button-Keys` via the existing 
  `MutationObserver` that already handles `.DocSearch-Search-Icon` and 
  `.DocSearch-Control-Key-Icon`

## Why
The keyboard shortcut is already conveyed through the button's `aria-label` 
attribute (`Rechercher sur le site (Ctrl+K)`). Exposing `.DocSearch-Button-Keys` 
to assistive technologies would result in redundant and potentially confusing 
information for screen reader users.

Closes #942 
